### PR TITLE
Refactor redux store requests to use axios bearer interceptor

### DIFF
--- a/src/redux-store/admin-referensi/ikk/index.js
+++ b/src/redux-store/admin-referensi/ikk/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify' // Import from react-toastify
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -21,13 +19,8 @@ const initialState = {
 
 export const getIkk = createAsyncThunk('ikk/getIkk', async (_, thunkAPI) => {
   let url = `/api/ikk`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -52,11 +45,7 @@ export const getIkk = createAsyncThunk('ikk/getIkk', async (_, thunkAPI) => {
 
 export const getDetailIkk = createAsyncThunk('ikk/getDetailIkk', async (_, thunkAPI) => {
   let url = `/api/ikk`
-  const session = await getSession()
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       inkf_id: `${thunkAPI.getState().ikk.inkf_id}`
     }
@@ -86,13 +75,8 @@ export const getDetailIkk = createAsyncThunk('ikk/getDetailIkk', async (_, thunk
 export const createIkk = createAsyncThunk('ikk/createIkk', async (dataform, thunkAPI) => {
   try {
     let url = `/api/ikk`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -110,13 +94,8 @@ export const createIkk = createAsyncThunk('ikk/createIkk', async (dataform, thun
 export const editIkk = createAsyncThunk('ikk/editIkk', async ({ ikk_item_id, dataform }, thunkAPI) => {
   try {
     let url = `/api/ikk/${ikk_item_id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -133,13 +112,8 @@ export const editIkk = createAsyncThunk('ikk/editIkk', async ({ ikk_item_id, dat
 
 export const deleteIkk = createAsyncThunk('ikk/deleteIkk', async (ikk_item_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/ikk/${ikk_item_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/ikk/${ikk_item_id}`)
 
     if (resp.data.status === 200) {
       return resp.data

--- a/src/redux-store/admin-referensi/inkf/index.js
+++ b/src/redux-store/admin-referensi/inkf/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -24,12 +22,7 @@ const initialState = {
 
 export const getInkf = createAsyncThunk('inkf/getInkf', async (_, thunkAPI) => {
   let url = `/api/inkf`
-  const session = await getSession()
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -54,11 +47,7 @@ export const getInkf = createAsyncThunk('inkf/getInkf', async (_, thunkAPI) => {
 
 export const getDetailInkf = createAsyncThunk('ikk/getDetailInkf', async (_, thunkAPI) => {
   let url = `/api/inkf`
-  const session = await getSession()
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       inkf_id: `${thunkAPI.getState().inkf.inkf_id}`
     }
@@ -88,12 +77,7 @@ export const getDetailInkf = createAsyncThunk('ikk/getDetailInkf', async (_, thu
 export const createInkf = createAsyncThunk('inkf/createInkf', async (dataform, thunkAPI) => {
   try {
     let url = `/api/inkf`
-    const session = await getSession()
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -111,12 +95,7 @@ export const createInkf = createAsyncThunk('inkf/createInkf', async (dataform, t
 export const editInkf = createAsyncThunk('inkf/editInkf', async ({ inkf_id, dataform }, thunkAPI) => {
   try {
     let url = `/api/inkf/${inkf_id}`
-    const session = await getSession()
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -133,13 +112,8 @@ export const editInkf = createAsyncThunk('inkf/editInkf', async ({ inkf_id, data
 
 export const deleteInkf = createAsyncThunk('inkf/deleteInkf', async (inkf_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/inkf/${inkf_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/inkf/${inkf_id}`)
 
     if (resp.data.status === 200) {
       return resp.data

--- a/src/redux-store/admin-referensi/kategori-jenjang/index.js
+++ b/src/redux-store/admin-referensi/kategori-jenjang/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -32,12 +30,7 @@ const initialState = {
 
 export const getkatInspektur = createAsyncThunk('kategoriJenjang/getkatInspektur', async (_, thunkAPI) => {
   let url = `/api/katInspektur`
-  const session = await getSession()
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -62,12 +55,7 @@ export const getkatInspektur = createAsyncThunk('kategoriJenjang/getkatInspektur
 
 export const getjenInspektur = createAsyncThunk('kategoriJenjang/getjenInspektur', async (_, thunkAPI) => {
   let url = `/api/jenInspektur`
-  const session = await getSession()
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -93,12 +81,7 @@ export const getjenInspektur = createAsyncThunk('kategoriJenjang/getjenInspektur
 export const createCategori = createAsyncThunk('kategoriJenjang/createCategori', async (dataform, thunkAPI) => {
   try {
     let url = `/api/katInspektur`
-    const session = await getSession()
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -115,13 +98,8 @@ export const createCategori = createAsyncThunk('kategoriJenjang/createCategori',
 
 export const deleteKategori = createAsyncThunk('kategoriJenjang/deleteKategori', async (insp_kat_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/katInspektur/${insp_kat_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/katInspektur/${insp_kat_id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -141,14 +119,9 @@ export const deleteKategori = createAsyncThunk('kategoriJenjang/deleteKategori',
 
 export const createJenjang = createAsyncThunk('kategoriJenjang/createJenjang', async (dataform, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/jenInspektur`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -165,13 +138,8 @@ export const createJenjang = createAsyncThunk('kategoriJenjang/createJenjang', a
 
 export const deleteJenjang = createAsyncThunk('kategoriJenjang/deleteJenjang', async (insp_jenjang_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/jenInspektur/${insp_jenjang_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/jenInspektur/${insp_jenjang_id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -194,12 +162,7 @@ export const editJenjang = createAsyncThunk(
   async ({ insp_jenjang_id, dataform }, thunkAPI) => {
     try {
       let url = `/api/jenInspektur/${insp_jenjang_id}`
-      const session = await getSession()
-      let config = {
-        headers: {
-          'balis-token': session.user.accessToken
-        }
-      }
+      let config = {}
       const resp = await customFetch.put(url, dataform, config)
 
       return resp.data

--- a/src/redux-store/admin-referensi/kelompok-kegiatan/index.js
+++ b/src/redux-store/admin-referensi/kelompok-kegiatan/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -27,13 +25,8 @@ const initialState = {
 
 export const getkelKegiatan = createAsyncThunk('kelKegiatan/getkelKegiatan', async (_, thunkAPI) => {
   let url = `/api/kelKegiatan`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken // Access the accessToken from the session
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -58,13 +51,8 @@ export const getkelKegiatan = createAsyncThunk('kelKegiatan/getkelKegiatan', asy
 
 export const getKegiatanKelompok = createAsyncThunk('kelKegiatan/getKegiatanKelompok', async (id, thunkAPI) => {
   let url = `/api/kelKegiatan/${id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -88,13 +76,9 @@ export const getKegiatanKelompok = createAsyncThunk('kelKegiatan/getKegiatanKelo
 })
 
 export const getKegiatan = createAsyncThunk('kelKegiatan/getKegiatan', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `/apiBalis/kegiatan`
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().kelKegiatan.current_page}`,
       limit: `${thunkAPI.getState().kelKegiatan.per_page}`,
@@ -128,13 +112,8 @@ export const editKegiatan = createAsyncThunk(
   'kelKegiatan/editKegiatan',
   async ({ kegiatan_id, dataform }, thunkAPI) => {
     try {
-      const session = await getSession()
 
-      const resp = await customFetch.put(`/api/kegiatanKel/update/${kegiatan_id}`, dataform, {
-        headers: {
-          'balis-token': session.user.accessToken
-        }
-      })
+      const resp = await customFetch.put(`/api/kegiatanKel/update/${kegiatan_id}`, dataform)
 
       return resp.data
     } catch (error) {
@@ -151,13 +130,8 @@ export const editKegiatan = createAsyncThunk(
 
 export const createKelompokKeg = createAsyncThunk('kelKegiatan/createKelompokKeg', async (dataform, thunkAPI) => {
   let url = `/api/kelKegiatan`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -177,13 +151,8 @@ export const createKelompokKeg = createAsyncThunk('kelKegiatan/createKelompokKeg
 export const editKelompokKeg = createAsyncThunk('kelKegiatan/editKelompokKeg', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/kelKegiatan/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -201,13 +170,8 @@ export const editKelompokKeg = createAsyncThunk('kelKegiatan/editKelompokKeg', a
 
 export const deleteKelompok = createAsyncThunk('kelKegiatan/deleteKelompok', async (id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/kelKegiatan/${id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/kelKegiatan/${id}`)
 
     if (resp.data.status === 200) {
       return resp.data

--- a/src/redux-store/admin-referensi/lkf-jenis-tabel/index.js
+++ b/src/redux-store/admin-referensi/lkf-jenis-tabel/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -21,13 +19,8 @@ const initialState = {
 
 export const getlkfJenisTabel = createAsyncThunk('lkfJenisTabel/getkatInspektur', async (_, thunkAPI) => {
   let url = `/api/lkfJenisTabel`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -53,13 +46,8 @@ export const getlkfJenisTabel = createAsyncThunk('lkfJenisTabel/getkatInspektur'
 export const createlkfJenisTabel = createAsyncThunk('lkfJenisTabel/createlkfJenisTabel', async (dataform, thunkAPI) => {
   try {
     let url = `/api/lkfJenisTabel`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -79,13 +67,8 @@ export const editlkfJenisTabel = createAsyncThunk(
   async ({ jenis_tabel_id, dataform }, thunkAPI) => {
     try {
       let url = `/api/lkfJenisTabel/${jenis_tabel_id}`
-      const session = await getSession()
 
-      let config = {
-        headers: {
-          'balis-token': session.user.accessToken
-        }
-      }
+      let config = {}
       const resp = await customFetch.put(url, dataform, config)
 
       return resp.data
@@ -105,13 +88,8 @@ export const deletelkfJenisTabel = createAsyncThunk(
   'lkfJenisTabel/deletelkfJenisTabel',
   async (jenis_tabel_id, thunkAPI) => {
     try {
-      const session = await getSession()
 
-      const resp = await customFetch.delete(`/api/lkfJenisTabel/${jenis_tabel_id}`, {
-        headers: {
-          'balis-token': session.user.accessToken
-        }
-      })
+      const resp = await customFetch.delete(`/api/lkfJenisTabel/${jenis_tabel_id}`)
 
       if (resp.data.status === 200) {
         return resp.data

--- a/src/redux-store/admin-referensi/syarat-item/index.js
+++ b/src/redux-store/admin-referensi/syarat-item/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -22,13 +20,8 @@ const initialState = {
 
 export const getsyaratItem = createAsyncThunk('syaratItem/getsyaratItem', async (_, thunkAPI) => {
   let url = `/api/syaratItem`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -54,13 +47,8 @@ export const getsyaratItem = createAsyncThunk('syaratItem/getsyaratItem', async 
 export const createSyaratItem = createAsyncThunk('syaratItem/createSyaratItem', async (dataform, thunkAPI) => {
   try {
     let url = `/api/syaratItem`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -78,13 +66,8 @@ export const createSyaratItem = createAsyncThunk('syaratItem/createSyaratItem', 
 export const editsyaratItem = createAsyncThunk('syaratItem/editsyaratItem', async ({ item_id, dataform }, thunkAPI) => {
   try {
     let url = `/api/syaratItem/${item_id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -101,13 +84,8 @@ export const editsyaratItem = createAsyncThunk('syaratItem/editsyaratItem', asyn
 
 export const deletesyaratItem = createAsyncThunk('syaratItem/deletesyaratItem', async (item_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/syaratItem/${item_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/syaratItem/${item_id}`)
 
     if (resp.data.status === 200) {
       return resp.data

--- a/src/redux-store/admin-referensi/tabel-setting/index.js
+++ b/src/redux-store/admin-referensi/tabel-setting/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -21,13 +19,8 @@ const initialState = {
 export const createInkfTabel = createAsyncThunk('tabel/createInkfTabel', async (dataform, thunkAPI) => {
   try {
     let url = `/api/inkfTabel`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -45,13 +38,8 @@ export const createInkfTabel = createAsyncThunk('tabel/createInkfTabel', async (
 export const editInkfTabel = createAsyncThunk('tabel/editInkfTabel', async ({ tabel_id, dataform }, thunkAPI) => {
   try {
     let url = `/api/inkfTabel/${tabel_id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -68,13 +56,8 @@ export const editInkfTabel = createAsyncThunk('tabel/editInkfTabel', async ({ ta
 
 export const deleteInkfTabel = createAsyncThunk('tabel/deleteInkfTabel', async (tabel_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/inkfTabel/${tabel_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/inkfTabel/${tabel_id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -95,13 +78,8 @@ export const deleteInkfTabel = createAsyncThunk('tabel/deleteInkfTabel', async (
 export const createLfkLib = createAsyncThunk('tabel/createLfkLib', async (dataform, thunkAPI) => {
   try {
     let url = `/api/lfkLib`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -119,13 +97,8 @@ export const createLfkLib = createAsyncThunk('tabel/createLfkLib', async (datafo
 export const editLfkLib = createAsyncThunk('tabel/editLfkLib', async ({ lkf_lib_id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lfkLib/${lkf_lib_id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -142,13 +115,8 @@ export const editLfkLib = createAsyncThunk('tabel/editLfkLib', async ({ lkf_lib_
 
 export const deleteLfkLib = createAsyncThunk('tabel/deleteLfkLib', async (lkf_lib_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lfkLib/${lkf_lib_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lfkLib/${lkf_lib_id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -168,13 +136,8 @@ export const deleteLfkLib = createAsyncThunk('tabel/deleteLfkLib', async (lkf_li
 
 export const getJenisTabel = createAsyncThunk('tabel/getJenisTabel', async thunkAPI => {
   let url = `/api/lkfJenisTabel`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -199,12 +162,8 @@ export const getJenisTabel = createAsyncThunk('tabel/getJenisTabel', async thunk
 
 export const getTabelKel = createAsyncThunk('tabel/getTabelKel', async (kelompok_id, thunkAPI) => {
   let url = `/api/tabelSetting`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       kelompok_id: `${kelompok_id}`
     }
@@ -231,13 +190,8 @@ export const getTabelKel = createAsyncThunk('tabel/getTabelKel', async (kelompok
 
 export const createTabel = createAsyncThunk('tabel/createTabel', async (dataform, thunkAPI) => {
   let url = `/api/tabelSetting`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -262,12 +216,8 @@ export const createTabel = createAsyncThunk('tabel/createTabel', async (dataform
 
 export const getStruktur = createAsyncThunk('tabel/getStruktur', async (tabel_id, thunkAPI) => {
   let url = `/api/strukturTabel`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       tabel_id: `${tabel_id}`
     }
@@ -295,13 +245,8 @@ export const getStruktur = createAsyncThunk('tabel/getStruktur', async (tabel_id
 export const createStruktur = createAsyncThunk('tabel/createStruktur', async (dataform, thunkAPI) => {
   try {
     let url = `/api/strukturTabel`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -319,13 +264,8 @@ export const createStruktur = createAsyncThunk('tabel/createStruktur', async (da
 export const editStruktur = createAsyncThunk('tabel/editStruktur', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/strukturTabel/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -343,12 +283,8 @@ export const editStruktur = createAsyncThunk('tabel/editStruktur', async ({ id, 
 
 export const deleteStruktur = createAsyncThunk('tabel/deleteStruktur', async (data, thunkAPI) => {
   try {
-    const session = await getSession()
 
     const resp = await customFetch.delete(`/api/strukturTabel/${data.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      },
       params: {
         tabel: `${data.tabel}`
       }
@@ -372,13 +308,8 @@ export const deleteStruktur = createAsyncThunk('tabel/deleteStruktur', async (da
 
 export const getTabelHeader = createAsyncThunk('tabel/getTabelHeader', async (tabel_id, thunkAPI) => {
   let url = `/api/getTabelHeader/${tabel_id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -401,13 +332,8 @@ export const getTabelHeader = createAsyncThunk('tabel/getTabelHeader', async (ta
 
 export const getTipeKolom = createAsyncThunk('tabel/getTipeKolom', async (_, thunkAPI) => {
   let url = `/api/getTipeKolom`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)

--- a/src/redux-store/admin-referensi/temuan/index.js
+++ b/src/redux-store/admin-referensi/temuan/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -35,13 +33,8 @@ const initialState = {
 
 export const getTemuanLib = createAsyncThunk('temuan/getTemuanLib', async (inkf_id, thunkAPI) => {
   let url = `/api/temuanLib`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -66,13 +59,8 @@ export const getTemuanLib = createAsyncThunk('temuan/getTemuanLib', async (inkf_
 
 export const getTemuanKel = createAsyncThunk('temuan/getTemuanKel', async (kelompok_id, thunkAPI) => {
   let url = `/api/temuan/${kelompok_id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -97,13 +85,8 @@ export const getTemuanKel = createAsyncThunk('temuan/getTemuanKel', async (kelom
 
 export const createTemuan = createAsyncThunk('temuan/createTemuan', async (dataform, thunkAPI) => {
   let url = `/api/temuan`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -128,12 +111,8 @@ export const createTemuan = createAsyncThunk('temuan/createTemuan', async (dataf
 
 export const getTemuanCreate = createAsyncThunk('temuan/getTemuanCreate', async (kelompok_id, thunkAPI) => {
   let url = `/api/temuanCreate`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       kelompok_id: `${kelompok_id}`
     }
@@ -163,13 +142,8 @@ export const getTemuanCreate = createAsyncThunk('temuan/getTemuanCreate', async 
 export const createItemLib = createAsyncThunk('temuan/createItemLib', async (dataform, thunkAPI) => {
   try {
     let url = `/api/temuanLib`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -187,13 +161,8 @@ export const createItemLib = createAsyncThunk('temuan/createItemLib', async (dat
 export const editItemLib = createAsyncThunk('temuan/editItemLib', async ({ temuan_id, dataform }, thunkAPI) => {
   try {
     let url = `/api/temuanLib/${temuan_id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -210,13 +179,8 @@ export const editItemLib = createAsyncThunk('temuan/editItemLib', async ({ temua
 
 export const deleteItemLib = createAsyncThunk('temuan/deleteItemLib', async (temuan_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/temuanLib/${temuan_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/temuanLib/${temuan_id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -236,13 +200,8 @@ export const deleteItemLib = createAsyncThunk('temuan/deleteItemLib', async (tem
 
 export const deleteTemuanKel = createAsyncThunk('temuan/deleteTemuanKel', async (acuan_id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/temuan/${acuan_id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/temuan/${acuan_id}`)
 
     if (resp.data.status === 200) {
       return resp.data

--- a/src/redux-store/admin-user/index.js
+++ b/src/redux-store/admin-user/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -24,12 +22,7 @@ const initialState = {
 export const getAkunInspeksi = createAsyncThunk('akun/getAkunInspeksi', async (accestoken, thunkAPI) => {
   let url = `api/akunInspeksi`
 
-  const session = await getSession()
-
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       fas_id: thunkAPI.getState().akun.fas_id,
       page: `${thunkAPI.getState().akun.current_page}`,
@@ -62,16 +55,7 @@ export const getAkunInspeksi = createAsyncThunk('akun/getAkunInspeksi', async (a
 
 export const getUserAkses = createAsyncThunk('akun/getUserAkses', async (id, thunkAPI) => {
   let url = `/api/getUserAkses`
-  const session = await getSession()
-
-  if (!session) {
-    return thunkAPI.rejectWithValue('Session not found')
-  }
-
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       user_id: id
     }
@@ -100,17 +84,7 @@ export const getUserAkses = createAsyncThunk('akun/getUserAkses', async (id, thu
 
 export const getRoleInspeksi = createAsyncThunk('akun/getRoleInspeksi', async (_, thunkAPI) => {
   let url = `/api/roleInspeksi`
-  const session = await getSession()
-
-  if (!session) {
-    return thunkAPI.rejectWithValue('Session not found')
-  }
-
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -136,13 +110,8 @@ export const getRoleInspeksi = createAsyncThunk('akun/getRoleInspeksi', async (_
 export const storeAkses = createAsyncThunk('akun/storeAkses', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/akunInspeksi/storeAkses/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.post(url, dataform, config)
 
     return resp.data
@@ -159,13 +128,8 @@ export const storeAkses = createAsyncThunk('akun/storeAkses', async ({ id, dataf
 
 export const deleteAkses = createAsyncThunk('akun/deleteAkses', async (id, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/akunInspeksi/deleteAkses/${id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/akunInspeksi/deleteAkses/${id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -185,13 +149,8 @@ export const deleteAkses = createAsyncThunk('akun/deleteAkses', async (id, thunk
 
 export const createRoleRef = createAsyncThunk('akun/createRoleRef', async (dataform, thunkAPI) => {
   let url = `/api/roleInspeksi`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -210,13 +169,8 @@ export const createRoleRef = createAsyncThunk('akun/createRoleRef', async (dataf
 
 export const getTokenVirtual = createAsyncThunk('authUser/getTokenVirtual', async (id, thunkAPI) => {
   let url = `/api/loginVirtual/${id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)

--- a/src/redux-store/auth/index.js
+++ b/src/redux-store/auth/index.js
@@ -9,13 +9,9 @@ const initialState = {
 
 export const postloginVirtual = createAsyncThunk('authUser/postloginVirtual', async ({ token }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/cekLoginVirtual/${token}`
 
     let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      },
       params: {
         akses_modul: 3
       }

--- a/src/redux-store/counting/index.js
+++ b/src/redux-store/counting/index.js
@@ -56,9 +56,6 @@ export const countRegistrasiSrpval = createAsyncThunk(
     }
 
     let config = {
-      headers: {
-        'balis-token': session?.user?.accessToken
-      },
       params: {
         tahap_reg_id: tahapan,
         validator_id: validator_id
@@ -107,9 +104,6 @@ export const countRegistrasiSrpoto = createAsyncThunk(
     }
 
     let config = {
-      headers: {
-        'balis-token': session?.user?.accessToken
-      },
       params: {
         tahap_reg_id: tahapan,
         koordinator_id: koordinator_id

--- a/src/redux-store/data-inspeksi/index.js
+++ b/src/redux-store/data-inspeksi/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -35,12 +33,8 @@ const initialState = {
 
 export const getDataJadwal = createAsyncThunk('dataInspeksi/getDataJadwal', async (_, thunkAPI) => {
   let url = `/api/data/jadwal`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataInspeksi.current_page}`,
       limit: `${thunkAPI.getState().dataInspeksi.per_page}`,
@@ -74,12 +68,8 @@ export const getDataJadwal = createAsyncThunk('dataInspeksi/getDataJadwal', asyn
 
 export const getJadwalProp = createAsyncThunk('dataInspeksi/getJadwalProp', async (_, thunkAPI) => {
   let url = `/api/data/jadwalProp`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataInspeksi.current_page}`,
       limit: `${thunkAPI.getState().dataInspeksi.per_page}`
@@ -109,12 +99,8 @@ export const getJadwalProp = createAsyncThunk('dataInspeksi/getJadwalProp', asyn
 
 export const getjadwalKab = createAsyncThunk('dataInspeksi/getjadwalKab', async (_, thunkAPI) => {
   let url = `/api/data/getjadwalKab`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataInspeksi.current_page}`,
       limit: `${thunkAPI.getState().dataInspeksi.per_page}`
@@ -144,13 +130,8 @@ export const getjadwalKab = createAsyncThunk('dataInspeksi/getjadwalKab', async 
 
 export const getBebanKerja = createAsyncThunk('dataInspeksi/getBebanKerja', async (_, thunkAPI) => {
   let url = `/api/data/inspektur/tahun`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -175,12 +156,8 @@ export const getBebanKerja = createAsyncThunk('dataInspeksi/getBebanKerja', asyn
 
 export const getInspekturDet = createAsyncThunk('dataInspeksi/getInspekturDet', async (_, thunkAPI) => {
   let url = `/api/data/inspektur/detail`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataInspeksi.current_page}`,
       limit: `${thunkAPI.getState().dataInspeksi.per_page}`
@@ -210,12 +187,8 @@ export const getInspekturDet = createAsyncThunk('dataInspeksi/getInspekturDet', 
 
 export const getInspekturTahun = createAsyncThunk('dataInspeksi/getInspekturTahun', async (_, thunkAPI) => {
   let url = `/api/data/inspektur/tahun/${tahun}`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataInspeksi.current_page}`,
       limit: `${thunkAPI.getState().dataInspeksi.per_page}`
@@ -245,12 +218,8 @@ export const getInspekturTahun = createAsyncThunk('dataInspeksi/getInspekturTahu
 
 export const getDataPengawasan = createAsyncThunk('dataInspeksi/getDataPengawasan', async (_, thunkAPI) => {
   let url = `/api/data/pengawasan`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataInspeksi.current_page}`,
       limit: `${thunkAPI.getState().dataInspeksi.per_page}`,
@@ -282,12 +251,8 @@ export const getDataPengawasan = createAsyncThunk('dataInspeksi/getDataPengawasa
 
 export const getDataFasilitas = createAsyncThunk('dataInspeksi/getDataFasilitas', async (_, thunkAPI) => {
   let url = `/api/data/fasilitas`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session?.user?.accessToken
-    },
     params: {
       page: thunkAPI.getState().dataInspeksi.current_page,
       limit: thunkAPI.getState().dataInspeksi.per_page,
@@ -317,12 +282,8 @@ export const getDataFasilitas = createAsyncThunk('dataInspeksi/getDataFasilitas'
 
 export const getInspekturThnDet = createAsyncThunk('dataInspeksi/getInspekturThnDet', async (id, thunkAPI) => {
   let url = `/api/data/inspektur/tahun/${id}`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataInspeksi.current_page}`,
       limit: `${thunkAPI.getState().dataInspeksi.per_page}`

--- a/src/redux-store/data-umum/index.js
+++ b/src/redux-store/data-umum/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -25,24 +23,18 @@ const initialState = {
 
 export const getDataJadwal = createAsyncThunk('dataUmum/getDataJadwal', async (_, thunkAPI) => {
   let url = `/api/data/jadwal`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
-    params: {
-      page: `${thunkAPI.getState().jadwal.current_page}`,
-      limit: `${thunkAPI.getState().jadwal.per_page}`,
-      status_id: thunkAPI.getState().jadwal.status,
-      propinsi_id: thunkAPI.getState().jadwal.propinsi_id,
-      bidang_id: thunkAPI.getState().jadwal.bidang_id,
-      fas_id: thunkAPI.getState().jadwal.fas_id
-    }
+  const params = {
+    page: `${thunkAPI.getState().jadwal.current_page}`,
+    limit: `${thunkAPI.getState().jadwal.per_page}`,
+    status_id: thunkAPI.getState().jadwal.status,
+    propinsi_id: thunkAPI.getState().jadwal.propinsi_id,
+    bidang_id: thunkAPI.getState().jadwal.bidang_id,
+    fas_id: thunkAPI.getState().jadwal.fas_id
   }
 
   try {
-    const resp = await customFetch.get(url, config)
+    const resp = await customFetch.get(url, { params })
 
     if (resp.data.status === 200) {
       return resp.data.response
@@ -64,24 +56,18 @@ export const getDataJadwal = createAsyncThunk('dataUmum/getDataJadwal', async (_
 
 export const getDataPengawasan = createAsyncThunk('dataUmum/getDataPengawasan', async (_, thunkAPI) => {
   let url = `/api/data/pengawasan`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
-    params: {
-      page: `${thunkAPI.getState().jadwal.current_page}`,
-      limit: `${thunkAPI.getState().jadwal.per_page}`,
-      status_id: thunkAPI.getState().jadwal.status,
-      propinsi_id: thunkAPI.getState().jadwal.propinsi_id,
-      bidang_id: thunkAPI.getState().jadwal.bidang_id,
-      fas_id: thunkAPI.getState().jadwal.fas_id
-    }
+  const params = {
+    page: `${thunkAPI.getState().jadwal.current_page}`,
+    limit: `${thunkAPI.getState().jadwal.per_page}`,
+    status_id: thunkAPI.getState().jadwal.status,
+    propinsi_id: thunkAPI.getState().jadwal.propinsi_id,
+    bidang_id: thunkAPI.getState().jadwal.bidang_id,
+    fas_id: thunkAPI.getState().jadwal.fas_id
   }
 
   try {
-    const resp = await customFetch.get(url, config)
+    const resp = await customFetch.get(url, { params })
 
     if (resp.data.status === 200) {
       return resp.data.response
@@ -103,24 +89,18 @@ export const getDataPengawasan = createAsyncThunk('dataUmum/getDataPengawasan', 
 
 export const getDataFasilitas = createAsyncThunk('dataUmum/getDataFasilitas', async (_, thunkAPI) => {
   let url = `/api/data/fasilitas`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
-    params: {
-      page: `${thunkAPI.getState().jadwal.current_page}`,
-      limit: `${thunkAPI.getState().jadwal.per_page}`,
-      status_id: thunkAPI.getState().jadwal.status,
-      propinsi_id: thunkAPI.getState().jadwal.propinsi_id,
-      bidang_id: thunkAPI.getState().jadwal.bidang_id,
-      fas_id: thunkAPI.getState().jadwal.fas_id
-    }
+  const params = {
+    page: `${thunkAPI.getState().jadwal.current_page}`,
+    limit: `${thunkAPI.getState().jadwal.per_page}`,
+    status_id: thunkAPI.getState().jadwal.status,
+    propinsi_id: thunkAPI.getState().jadwal.propinsi_id,
+    bidang_id: thunkAPI.getState().jadwal.bidang_id,
+    fas_id: thunkAPI.getState().jadwal.fas_id
   }
 
   try {
-    const resp = await customFetch.get(url, config)
+    const resp = await customFetch.get(url, { params })
 
     if (resp.data.status === 200) {
       return resp.data.response

--- a/src/redux-store/fihi/dataFihi.js
+++ b/src/redux-store/fihi/dataFihi.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -40,12 +38,8 @@ const initialState = {
 
 export const getFihiSumber = createAsyncThunk('dataFihi/fihiSumber', async (_, thunkAPI) => {
   let url = `/api/fihiSumber`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataFihi.current_pageSrp}`,
       limit: `${thunkAPI.getState().dataFihi.per_page}`,
@@ -77,13 +71,8 @@ export const getFihiSumber = createAsyncThunk('dataFihi/fihiSumber', async (_, t
 
 export const createFihiSumber = createAsyncThunk('dataFihi/createFihiSumber', async (dataform, thunkAPI) => {
   let url = `/api/fihiSumber`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -105,13 +94,8 @@ export const createFihiSumber = createAsyncThunk('dataFihi/createFihiSumber', as
 export const editFihiSumber = createAsyncThunk('dataFihi/editFihiSumber', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/fihiSumber/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -135,13 +119,8 @@ export const editFihiSumber = createAsyncThunk('dataFihi/editFihiSumber', async 
 
 export const deleteFihiSumber = createAsyncThunk('dataFihi/deleteFihiSumber', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/fihiSumber/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/fihiSumber/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -161,14 +140,10 @@ export const deleteFihiSumber = createAsyncThunk('dataFihi/deleteFihiSumber', as
 
 export const getFihiPekerja = createAsyncThunk('dataFihi/getFihiPekerja', async (searchTerm = '', thunkAPI) => {
   let url = `/api/fihiPekerja`
-  const session = await getSession()
 
   console.log(searchTerm)
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataFihi.current_page}`,
       limit: `${thunkAPI.getState().dataFihi.per_page}`,
@@ -200,13 +175,8 @@ export const getFihiPekerja = createAsyncThunk('dataFihi/getFihiPekerja', async 
 
 export const createFihiPekerja = createAsyncThunk('dataFihi/createFihiPekerja', async (dataform, thunkAPI) => {
   let url = `/api/fihiPekerja`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -226,13 +196,8 @@ export const createFihiPekerja = createAsyncThunk('dataFihi/createFihiPekerja', 
 export const editFihiPekerja = createAsyncThunk('dataFihi/editFihiPekerja', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/fihiPekerja/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -252,13 +217,8 @@ export const editFihiPekerja = createAsyncThunk('dataFihi/editFihiPekerja', asyn
 
 export const deleteFihiPekerja = createAsyncThunk('dataFihi/deleteFihiPekerja', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/fihiPekerja/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/fihiPekerja/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -278,13 +238,8 @@ export const deleteFihiPekerja = createAsyncThunk('dataFihi/deleteFihiPekerja', 
 
 export const fihiPekerjaStore = createAsyncThunk('dataFihi/fihiPekerjaStore', async (dataform, thunkAPI) => {
   let url = `/api/fihiPekerjaStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -303,12 +258,8 @@ export const fihiPekerjaStore = createAsyncThunk('dataFihi/fihiPekerjaStore', as
 
 export const getFihiDosis = createAsyncThunk('dataFihi/getFihiDosis', async (_, thunkAPI) => {
   let url = `/api/fihiDosis`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataFihi.current_page}`,
       limit: `${thunkAPI.getState().dataFihi.per_page}`,
@@ -340,13 +291,8 @@ export const getFihiDosis = createAsyncThunk('dataFihi/getFihiDosis', async (_, 
 
 export const createFihiDosis = createAsyncThunk('dataFihi/createFihiDosis', async (dataform, thunkAPI) => {
   let url = `/api/fihiDosis`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -366,13 +312,8 @@ export const createFihiDosis = createAsyncThunk('dataFihi/createFihiDosis', asyn
 export const editFihiDosis = createAsyncThunk('dataFihi/editFihiDosis', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/fihiDosis/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -392,13 +333,8 @@ export const editFihiDosis = createAsyncThunk('dataFihi/editFihiDosis', async ({
 
 export const deleteFihiDosis = createAsyncThunk('dataFihi/deleteFihiDosis', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/fihiDosis/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/fihiDosis/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -418,13 +354,8 @@ export const deleteFihiDosis = createAsyncThunk('dataFihi/deleteFihiDosis', asyn
 
 export const fihiDosisStore = createAsyncThunk('dataFihi/fihiDosisStore', async (dataform, thunkAPI) => {
   let url = `/api/fihiDosisStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -443,12 +374,8 @@ export const fihiDosisStore = createAsyncThunk('dataFihi/fihiDosisStore', async 
 
 export const getFihiKes = createAsyncThunk('dataFihi/getFihiKes', async (_, thunkAPI) => {
   let url = `/api/fihiKes`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataFihi.current_page}`,
       limit: `${thunkAPI.getState().dataFihi.per_page}`
@@ -478,13 +405,8 @@ export const getFihiKes = createAsyncThunk('dataFihi/getFihiKes', async (_, thun
 
 export const createFihikes = createAsyncThunk('dataFihi/createFihikes', async (dataform, thunkAPI) => {
   let url = `/api/fihiKes`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -503,13 +425,8 @@ export const createFihikes = createAsyncThunk('dataFihi/createFihikes', async (d
 
 export const deleteFihiKes = createAsyncThunk('dataFihi/deleteFihiKes', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/fihiKes/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/fihiKes/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -529,13 +446,8 @@ export const deleteFihiKes = createAsyncThunk('dataFihi/deleteFihiKes', async (p
 
 export const fihiKesStore = createAsyncThunk('dataFihi/fihiKesStore', async (dataform, thunkAPI) => {
   let url = `/api/fihiKesStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -555,13 +467,8 @@ export const fihiKesStore = createAsyncThunk('dataFihi/fihiKesStore', async (dat
 export const editFihiKes = createAsyncThunk('dataFihi/editFihiKes', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/fihiKes/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -581,12 +488,8 @@ export const editFihiKes = createAsyncThunk('dataFihi/editFihiKes', async ({ id,
 
 export const getFihiDok = createAsyncThunk('dataFihi/fihiDok', async (_, thunkAPI) => {
   let url = `/api/fihiDok`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataFihi.current_page}`,
       limit: `${thunkAPI.getState().dataFihi.per_page}`,
@@ -618,13 +521,8 @@ export const getFihiDok = createAsyncThunk('dataFihi/fihiDok', async (_, thunkAP
 
 export const createFihiDok = createAsyncThunk('dataFihi/createFihiDok', async (dataform, thunkAPI) => {
   let url = `/api/fihiDok`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)

--- a/src/redux-store/fihi/index.js
+++ b/src/redux-store/fihi/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -42,14 +40,10 @@ const initialState = {
 
 export const getFihi = createAsyncThunk('fihi/getFihi', async (_, thunkAPI) => {
   let url = `/api/fihi`
-  const session = await getSession()
 
   const insep = `${thunkAPI.getState().jadwal.insp_master_id}`
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().fihi.current_page}`,
       limit: `${thunkAPI.getState().fihi.per_page}`,
@@ -81,12 +75,8 @@ export const getFihi = createAsyncThunk('fihi/getFihi', async (_, thunkAPI) => {
 
 export const getfihiJadwal = createAsyncThunk('fihi/getfihiJadwal', async (id, thunkAPI) => {
   let url = `/api/fihi`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       limit: `${thunkAPI.getState().fihi.per_page}`,
       status: `${thunkAPI.getState().fihi.status}`,
@@ -117,13 +107,8 @@ export const getfihiJadwal = createAsyncThunk('fihi/getfihiJadwal', async (id, t
 
 export const getdataFihi = createAsyncThunk('fihi/getdataFihi', async (id, thunkAPI) => {
   let url = `/api/fihi/${id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -148,13 +133,8 @@ export const getdataFihi = createAsyncThunk('fihi/getdataFihi', async (id, thunk
 
 export const createFihi = createAsyncThunk('fihi/createFihi', async (dataform, thunkAPI) => {
   let url = `/api/fihi`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -173,12 +153,8 @@ export const createFihi = createAsyncThunk('fihi/createFihi', async (dataform, t
 
 export const getFihiPihak = createAsyncThunk('fihi/getFihiPihak', async (id, thunkAPI) => {
   let url = `/api/fihiPihak`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       limit: `${thunkAPI.getState().fihi.per_page}`,
       fihi_id: id
@@ -208,13 +184,8 @@ export const getFihiPihak = createAsyncThunk('fihi/getFihiPihak', async (id, thu
 
 export const createFihiPihak = createAsyncThunk('fihi/createFihiPihak', async (dataform, thunkAPI) => {
   let url = `/api/fihiPihak`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -234,13 +205,8 @@ export const createFihiPihak = createAsyncThunk('fihi/createFihiPihak', async (d
 export const editFihiPihak = createAsyncThunk('fihi/editFihiPihak', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/fihiPihak/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -258,13 +224,8 @@ export const editFihiPihak = createAsyncThunk('fihi/editFihiPihak', async ({ id,
 
 export const deleteFihiPihak = createAsyncThunk('fihi/deleteFihiPihak', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/fihiPihak/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/fihiPihak/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -284,13 +245,8 @@ export const deleteFihiPihak = createAsyncThunk('fihi/deleteFihiPihak', async (p
 
 export const fihiFormTabel = createAsyncThunk('fihi/fihiFormTabel', async (dataform, thunkAPI) => {
   let url = `/api/fihiFormTabel`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -309,14 +265,9 @@ export const fihiFormTabel = createAsyncThunk('fihi/fihiFormTabel', async (dataf
 
 export const fihiFormTabeledit = createAsyncThunk('fihi/fihiFormTabeledit', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/fihiFormTabel/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -334,12 +285,8 @@ export const fihiFormTabeledit = createAsyncThunk('fihi/fihiFormTabeledit', asyn
 
 export const fihiFormTabeldelete = createAsyncThunk('fihi/fihiFormTabeldelete', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
     const resp = await customFetch.delete(`/api/fihiFormTabel/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      },
       params: {
         fihi_id: params.fihi_id
       }
@@ -363,14 +310,9 @@ export const fihiFormTabeldelete = createAsyncThunk('fihi/fihiFormTabeldelete', 
 
 export const simpanForm = createAsyncThunk('fihi/simpanForm', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/fihi/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -388,14 +330,9 @@ export const simpanForm = createAsyncThunk('fihi/simpanForm', async ({ id, dataf
 
 export const fihiSimpan = createAsyncThunk('fihi/fihiSimpan', async ({ fihi_id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/fihiSimpan/${fihi_id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -412,13 +349,8 @@ export const fihiSimpan = createAsyncThunk('fihi/fihiSimpan', async ({ fihi_id, 
 
 export const deleteFihi = createAsyncThunk('fihi/deleteFihi', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/fihi/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/fihi/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -437,12 +369,10 @@ export const deleteFihi = createAsyncThunk('fihi/deleteFihi', async (params, thu
 })
 
 export const uploadFihiDok = createAsyncThunk('fihi/uploadFihiDok', async (dataform, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/fihi/dok`
 
   let config = {
     headers: {
-      'balis-token': session.user.accessToken,
       'Content-Type': 'multipart/form-data'
     }
   }
@@ -464,13 +394,8 @@ export const uploadFihiDok = createAsyncThunk('fihi/uploadFihiDok', async (dataf
 
 export const deleteFihiDok = createAsyncThunk('fihi/deleteFihiDok', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/fihi/dok/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/fihi/dok/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -490,14 +415,9 @@ export const deleteFihiDok = createAsyncThunk('fihi/deleteFihiDok', async (param
 
 export const fihiSelesai = createAsyncThunk('fihi/fihiSelesai', async (fihi_id, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/fihiSelesai/${fihi_id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, fihi_id, config)
 
     return resp.data
@@ -513,13 +433,9 @@ export const fihiSelesai = createAsyncThunk('fihi/fihiSelesai', async (fihi_id, 
 })
 
 export const getDokumenfihi = createAsyncThunk('fihi/getDokumenfihi', async (id, thunkAPI) => {
-  const session = await getSession()
   const url = `/api/fihi/dok/${id}`
 
   const config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     responseType: 'blob' // Set response type to blob to handle binary data
   }
 

--- a/src/redux-store/jadwal-fas/index.js
+++ b/src/redux-store/jadwal-fas/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -28,12 +26,8 @@ const initialState = {
 
 export const getJadwalFas = createAsyncThunk('jadwalFas/getJadwalFas', async (_, thunkAPI) => {
   let url = `/api/jadwalFas`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().jadwalFas.current_page}`,
       limit: `${thunkAPI.getState().jadwalFas.per_page}`,
@@ -67,13 +61,8 @@ export const getJadwalFas = createAsyncThunk('jadwalFas/getJadwalFas', async (_,
 
 export const jadwalKonfirm = createAsyncThunk('jadwalFas/jadwalKonfirm', async (dataform, thunkAPI) => {
   let url = `/api/jadwalKonfirm/fas`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -92,13 +81,8 @@ export const jadwalKonfirm = createAsyncThunk('jadwalFas/jadwalKonfirm', async (
 
 export const jadwalKonfirmSimpan = createAsyncThunk('jadwalFas/jadwalKonfirmSimpan', async (dataform, thunkAPI) => {
   let url = `/api/jadwalKonfirm/simpan`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -117,13 +101,8 @@ export const jadwalKonfirmSimpan = createAsyncThunk('jadwalFas/jadwalKonfirmSimp
 
 export const selesaiJadwalFas = createAsyncThunk('jadwalFas/selesaiJadwalFas', async (id, thunkAPI) => {
   let url = `/api/jadwalKonfirm/selesai/${id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.put(url, id, config)

--- a/src/redux-store/lhi/dataLhi.js
+++ b/src/redux-store/lhi/dataLhi.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -40,12 +38,8 @@ const initialState = {
 
 export const getLhiSumber = createAsyncThunk('dataLhi/lhiSumber', async (_, thunkAPI) => {
   let url = `/api/lhiSumber`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLhi.current_pageSrp}`,
       limit: `${thunkAPI.getState().dataLhi.per_page}`,
@@ -77,13 +71,8 @@ export const getLhiSumber = createAsyncThunk('dataLhi/lhiSumber', async (_, thun
 
 export const createLhiSumber = createAsyncThunk('dataLhi/createLhiSumber', async (dataform, thunkAPI) => {
   let url = `/api/lhiSumber`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -102,14 +91,9 @@ export const createLhiSumber = createAsyncThunk('dataLhi/createLhiSumber', async
 
 export const editLhiSumber = createAsyncThunk('dataLhi/editLhiSumber', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lhiSumber/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -131,13 +115,8 @@ export const editLhiSumber = createAsyncThunk('dataLhi/editLhiSumber', async ({ 
 
 export const deleteLhiSumber = createAsyncThunk('dataLhi/deleteLhiSumber', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lhiSumber/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lhiSumber/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -157,14 +136,10 @@ export const deleteLhiSumber = createAsyncThunk('dataLhi/deleteLhiSumber', async
 
 export const getLhiPekerja = createAsyncThunk('dataLhi/getLhiPekerja', async (searchTerm = '', thunkAPI) => {
   let url = `/api/lhiPekerja`
-  const session = await getSession()
 
   console.log(searchTerm)
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLhi.current_page}`,
       limit: `${thunkAPI.getState().dataLhi.per_page}`,
@@ -196,13 +171,8 @@ export const getLhiPekerja = createAsyncThunk('dataLhi/getLhiPekerja', async (se
 
 export const createLhiPekerja = createAsyncThunk('dataLhi/createLhiPekerja', async (dataform, thunkAPI) => {
   let url = `/api/lhiPekerja`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -221,14 +191,9 @@ export const createLhiPekerja = createAsyncThunk('dataLhi/createLhiPekerja', asy
 
 export const editLhiPekerja = createAsyncThunk('dataLhi/editLhiPekerja', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lhiPekerja/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -246,13 +211,8 @@ export const editLhiPekerja = createAsyncThunk('dataLhi/editLhiPekerja', async (
 
 export const deleteLhiPekerja = createAsyncThunk('dataLhi/deleteLhiPekerja', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lhiPekerja/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lhiPekerja/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -272,13 +232,8 @@ export const deleteLhiPekerja = createAsyncThunk('dataLhi/deleteLhiPekerja', asy
 
 export const lhiPekerjaStore = createAsyncThunk('dataLhi/lhiPekerjaStore', async (dataform, thunkAPI) => {
   let url = `/api/lhiPekerjaStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -297,12 +252,8 @@ export const lhiPekerjaStore = createAsyncThunk('dataLhi/lhiPekerjaStore', async
 
 export const getLhiDosis = createAsyncThunk('dataLhi/getLhiDosis', async (_, thunkAPI) => {
   let url = `/api/lhiDosis`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLhi.current_page}`,
       limit: `${thunkAPI.getState().dataLhi.per_page}`,
@@ -334,13 +285,8 @@ export const getLhiDosis = createAsyncThunk('dataLhi/getLhiDosis', async (_, thu
 
 export const createLhiDosis = createAsyncThunk('dataLhi/createLhiDosis', async (dataform, thunkAPI) => {
   let url = `/api/lhiDosis`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -360,13 +306,8 @@ export const createLhiDosis = createAsyncThunk('dataLhi/createLhiDosis', async (
 export const editLhiDosis = createAsyncThunk('dataLhi/editLhiDosis', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lhiDosis/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -384,13 +325,8 @@ export const editLhiDosis = createAsyncThunk('dataLhi/editLhiDosis', async ({ id
 
 export const deleteLhiDosis = createAsyncThunk('dataLhi/deleteLhiDosis', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lhiDosis/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lhiDosis/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -410,13 +346,8 @@ export const deleteLhiDosis = createAsyncThunk('dataLhi/deleteLhiDosis', async (
 
 export const lhiDosisStore = createAsyncThunk('dataLhi/lhiDosisStore', async (dataform, thunkAPI) => {
   let url = `/api/lhiDosisStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -435,12 +366,8 @@ export const lhiDosisStore = createAsyncThunk('dataLhi/lhiDosisStore', async (da
 
 export const getLhiKes = createAsyncThunk('dataLhi/getLhiKes', async (_, thunkAPI) => {
   let url = `/api/lhiKes`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLhi.current_page}`,
       limit: `${thunkAPI.getState().dataLhi.per_page}`
@@ -470,13 +397,8 @@ export const getLhiKes = createAsyncThunk('dataLhi/getLhiKes', async (_, thunkAP
 
 export const createLhikes = createAsyncThunk('dataLhi/createLhikes', async (dataform, thunkAPI) => {
   let url = `/api/lhiKes`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -497,13 +419,8 @@ export const createLhikes = createAsyncThunk('dataLhi/createLhikes', async (data
 
 export const deleteLhiKes = createAsyncThunk('dataLhi/deleteLhiKes', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lhiKes/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lhiKes/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -525,13 +442,8 @@ export const deleteLhiKes = createAsyncThunk('dataLhi/deleteLhiKes', async (para
 
 export const lhiKesStore = createAsyncThunk('dataLhi/lhiKesStore', async (dataform, thunkAPI) => {
   let url = `/api/lhiKesStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -553,13 +465,8 @@ export const lhiKesStore = createAsyncThunk('dataLhi/lhiKesStore', async (datafo
 export const editLhiKes = createAsyncThunk('dataLhi/editLhiKes', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lhiKes/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -579,12 +486,8 @@ export const editLhiKes = createAsyncThunk('dataLhi/editLhiKes', async ({ id, da
 
 export const getLhiDok = createAsyncThunk('dataLhi/lhiDok', async (_, thunkAPI) => {
   let url = `/api/lhiDok`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLhi.current_page}`,
       limit: `${thunkAPI.getState().dataLhi.per_page}`,
@@ -616,13 +519,8 @@ export const getLhiDok = createAsyncThunk('dataLhi/lhiDok', async (_, thunkAPI) 
 
 export const createLhiDok = createAsyncThunk('dataLhi/createLhiDok', async (dataform, thunkAPI) => {
   let url = `/api/lhiDok`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)

--- a/src/redux-store/lhi/index.js
+++ b/src/redux-store/lhi/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import {
   LHI_BATAL,
   LHI_CETAK,
@@ -51,12 +49,8 @@ const initialState = {
 
 export const getLhi = createAsyncThunk('lhi/getLhi', async (_, thunkAPI) => {
   let url = `/api/lhi`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().lhi.current_page}`,
       limit: `${thunkAPI.getState().lhi.per_page}`,
@@ -90,13 +84,8 @@ export const getLhi = createAsyncThunk('lhi/getLhi', async (_, thunkAPI) => {
 
 export const createLhi = createAsyncThunk('lhi/createLhi', async (dataform, thunkAPI) => {
   let url = `/api/lhi`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -115,13 +104,8 @@ export const createLhi = createAsyncThunk('lhi/createLhi', async (dataform, thun
 
 export const getdataLhi = createAsyncThunk('lhi/getdataLhi', async (id, thunkAPI) => {
   let url = `/api/lhi/${id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -146,13 +130,8 @@ export const getdataLhi = createAsyncThunk('lhi/getdataLhi', async (id, thunkAPI
 
 export const deleteLhi = createAsyncThunk('lhi/deleteLhi', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lhi/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lhi/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -172,12 +151,8 @@ export const deleteLhi = createAsyncThunk('lhi/deleteLhi', async (params, thunkA
 
 export const getLhiPihak = createAsyncThunk('lhi/getLhiPihak', async (id, thunkAPI) => {
   let url = `/api/lhiPihak`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       limit: `${thunkAPI.getState().lhi.per_page}`,
       lhi_id: id
@@ -207,13 +182,8 @@ export const getLhiPihak = createAsyncThunk('lhi/getLhiPihak', async (id, thunkA
 
 export const createLhiPihak = createAsyncThunk('lhi/createLhiPihak', async (dataform, thunkAPI) => {
   let url = `/api/lhiPihak`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -233,13 +203,8 @@ export const createLhiPihak = createAsyncThunk('lhi/createLhiPihak', async (data
 export const editLhiPihak = createAsyncThunk('lhi/editLhiPihak', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lhiPihak/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -257,13 +222,8 @@ export const editLhiPihak = createAsyncThunk('lhi/editLhiPihak', async ({ id, da
 
 export const deleteLhiPihak = createAsyncThunk('lhi/deleteLhiPihak', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lhiPihak/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lhiPihak/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -284,13 +244,8 @@ export const deleteLhiPihak = createAsyncThunk('lhi/deleteLhiPihak', async (para
 export const editLhitemuan = createAsyncThunk('lhi/editLhitemuan', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lhiTemuan/edit/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -309,13 +264,8 @@ export const editLhitemuan = createAsyncThunk('lhi/editLhitemuan', async ({ id, 
 export const editLhilokasi = createAsyncThunk('lhi/editLhilokasi', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lhi/lokasi/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -334,13 +284,8 @@ export const editLhilokasi = createAsyncThunk('lhi/editLhilokasi', async ({ id, 
 export const updateLhi = createAsyncThunk('lhi/updateLhi', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lhi/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -359,13 +304,8 @@ export const updateLhi = createAsyncThunk('lhi/updateLhi', async ({ id, dataform
 export const lhiKirimVer = createAsyncThunk('lhi/lhiKirimVer', async (lhi_id, thunkAPI) => {
   try {
     let url = `/api/lhiKirim/verif/${lhi_id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, lhi_id, config)
 
     return resp.data
@@ -383,13 +323,8 @@ export const lhiKirimVer = createAsyncThunk('lhi/lhiKirimVer', async (lhi_id, th
 export const lhiKirimKoor = createAsyncThunk('lhi/lhiKirimKoor', async (lhi_id, thunkAPI) => {
   try {
     let url = `/api/lhiKirim/Koor/${lhi_id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, lhi_id, config)
 
     return resp.data
@@ -406,13 +341,8 @@ export const lhiKirimKoor = createAsyncThunk('lhi/lhiKirimKoor', async (lhi_id, 
 
 export const lhiFormTabel = createAsyncThunk('lhi/lhiFormTabel', async (dataform, thunkAPI) => {
   let url = `/api/lhiFormTabel`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -431,14 +361,9 @@ export const lhiFormTabel = createAsyncThunk('lhi/lhiFormTabel', async (dataform
 
 export const lhiFormTabeledit = createAsyncThunk('lhi/lhiFormTabeledit', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lhiFormTabel/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -458,12 +383,8 @@ export const lhiFormTabeledit = createAsyncThunk('lhi/lhiFormTabeledit', async (
 
 export const lhiFormTabeldelete = createAsyncThunk('lhi/lhiFormTabeldelete', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
     const resp = await customFetch.delete(`/api/lhiFormTabel/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      },
       params: {
         lhi_id: params.lhi_id
       }
@@ -489,14 +410,9 @@ export const lhiFormTabeldelete = createAsyncThunk('lhi/lhiFormTabeldelete', asy
 
 export const lhiSelesai = createAsyncThunk('lhi/lhiSelesai', async (lhi_id, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lhiSelesai/${lhi_id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, lhi_id, config)
 
     return resp.data
@@ -514,13 +430,9 @@ export const lhiSelesai = createAsyncThunk('lhi/lhiSelesai', async (lhi_id, thun
 })
 
 export const getDokumenlhi = createAsyncThunk('lhi/getDokumenlhi', async (id, thunkAPI) => {
-  const session = await getSession()
   const url = `/api/lhi/dok/${id}`
 
   const config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     responseType: 'blob' // Set response type to blob to handle binary data
   }
 
@@ -548,13 +460,8 @@ export const getDokumenlhi = createAsyncThunk('lhi/getDokumenlhi', async (id, th
 
 export const deleteLhiDok = createAsyncThunk('lhi/deleteLhiDok', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lhi/dok/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lhi/dok/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -573,12 +480,10 @@ export const deleteLhiDok = createAsyncThunk('lhi/deleteLhiDok', async (params, 
 })
 
 export const uploadLhiDok = createAsyncThunk('lhi/uploadLhiDok', async (dataform, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/lhi/dok`
 
   let config = {
     headers: {
-      'balis-token': session.user.accessToken,
       'Content-Type': 'multipart/form-data'
     }
   }

--- a/src/redux-store/lkf/dataLkf.js
+++ b/src/redux-store/lkf/dataLkf.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -41,12 +39,8 @@ const initialState = {
 
 export const getLkfSumber = createAsyncThunk('dataLkf/lkfSumber', async (_, thunkAPI) => {
   let url = `/api/lkfSumber`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLkf.current_pageSrp}`,
       limit: `${thunkAPI.getState().dataLkf.per_page}`,
@@ -78,13 +72,8 @@ export const getLkfSumber = createAsyncThunk('dataLkf/lkfSumber', async (_, thun
 
 export const createLkfSumber = createAsyncThunk('dataLkf/createLkfSumber', async (dataform, thunkAPI) => {
   let url = `/api/lkfSumber`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -104,13 +93,11 @@ export const createLkfSumber = createAsyncThunk('dataLkf/createLkfSumber', async
 export const editLkfSumber = createAsyncThunk('dataLkf/editLkfSumber', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lkfSumber/${id}`
-    const session = await getSession()
 
     let config = {
       headers: {
         'Content-Type': 'application/json',
-        Accept: 'application/json',
-        'balis-token': session.user.accessToken
+        Accept: 'application/json'
       }
     }
 
@@ -132,13 +119,8 @@ export const editLkfSumber = createAsyncThunk('dataLkf/editLkfSumber', async ({ 
 
 export const deleteLkfSumber = createAsyncThunk('dataLkf/deleteLkfSumber', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lkfSumber/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lkfSumber/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -158,12 +140,8 @@ export const deleteLkfSumber = createAsyncThunk('dataLkf/deleteLkfSumber', async
 
 export const getLkfPekerja = createAsyncThunk('dataLkf/getLkfPekerja', async (searchTerm = '', thunkAPI) => {
   let url = `/api/lkfPekerja`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLkf.current_page}`,
       limit: `${thunkAPI.getState().dataLkf.per_page}`,
@@ -195,13 +173,8 @@ export const getLkfPekerja = createAsyncThunk('dataLkf/getLkfPekerja', async (se
 
 export const createLkfPekerja = createAsyncThunk('dataLkf/createLkfPekerja', async (dataform, thunkAPI) => {
   let url = `/api/lkfPekerja`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -221,13 +194,8 @@ export const createLkfPekerja = createAsyncThunk('dataLkf/createLkfPekerja', asy
 export const editLkfPekerja = createAsyncThunk('dataLkf/editLkfPekerja', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lkfPekerja/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -245,13 +213,8 @@ export const editLkfPekerja = createAsyncThunk('dataLkf/editLkfPekerja', async (
 
 export const deleteLkfPekerja = createAsyncThunk('dataLkf/deleteLkfPekerja', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lkfPekerja/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lkfPekerja/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -271,13 +234,8 @@ export const deleteLkfPekerja = createAsyncThunk('dataLkf/deleteLkfPekerja', asy
 
 export const lkfPekerjaStore = createAsyncThunk('dataLkf/lkfPekerjaStore', async (dataform, thunkAPI) => {
   let url = `/api/lkfPekerjaStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -296,12 +254,8 @@ export const lkfPekerjaStore = createAsyncThunk('dataLkf/lkfPekerjaStore', async
 
 export const getLkfDosis = createAsyncThunk('dataLkf/getLkfDosis', async (_, thunkAPI) => {
   let url = `/api/lkfDosis`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLkf.current_page}`,
       limit: `${thunkAPI.getState().dataLkf.per_page}`,
@@ -333,13 +287,8 @@ export const getLkfDosis = createAsyncThunk('dataLkf/getLkfDosis', async (_, thu
 
 export const createLkfDosis = createAsyncThunk('dataLkf/createLkfDosis', async (dataform, thunkAPI) => {
   let url = `/api/lkfDosis`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -359,13 +308,8 @@ export const createLkfDosis = createAsyncThunk('dataLkf/createLkfDosis', async (
 export const editLkfDosis = createAsyncThunk('dataLkf/editLkfDosis', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lkfDosis/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -383,13 +327,8 @@ export const editLkfDosis = createAsyncThunk('dataLkf/editLkfDosis', async ({ id
 
 export const deleteLkfDosis = createAsyncThunk('dataLkf/deleteLkfDosis', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lkfDosis/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lkfDosis/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -409,13 +348,8 @@ export const deleteLkfDosis = createAsyncThunk('dataLkf/deleteLkfDosis', async (
 
 export const lkfDosisStore = createAsyncThunk('dataLkf/lkfDosisStore', async (dataform, thunkAPI) => {
   let url = `/api/lkfDosisStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -434,12 +368,8 @@ export const lkfDosisStore = createAsyncThunk('dataLkf/lkfDosisStore', async (da
 
 export const getLkfKes = createAsyncThunk('dataLkf/getLkfKes', async (_, thunkAPI) => {
   let url = `/api/lkfKes`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLkf.current_page}`,
       limit: `${thunkAPI.getState().dataLkf.per_page}`,
@@ -471,13 +401,8 @@ export const getLkfKes = createAsyncThunk('dataLkf/getLkfKes', async (_, thunkAP
 
 export const createLkfkes = createAsyncThunk('dataLkf/createLkfkes', async (dataform, thunkAPI) => {
   let url = `/api/lkfKes`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -496,13 +421,8 @@ export const createLkfkes = createAsyncThunk('dataLkf/createLkfkes', async (data
 
 export const deleteLkfKes = createAsyncThunk('dataLkf/deleteLkfKes', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.delete(`/api/lkfKes/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.delete(`/api/lkfKes/${params.id}`)
 
     if (resp.data.status === 200) {
       return resp.data
@@ -522,13 +442,8 @@ export const deleteLkfKes = createAsyncThunk('dataLkf/deleteLkfKes', async (para
 
 export const lkfKesStore = createAsyncThunk('dataLkf/lkfKesStore', async (dataform, thunkAPI) => {
   let url = `/api/lkfKesStore`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -547,14 +462,9 @@ export const lkfKesStore = createAsyncThunk('dataLkf/lkfKesStore', async (datafo
 
 export const editLkfKes = createAsyncThunk('dataLkf/editLkfKes', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lkfKes/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -572,12 +482,8 @@ export const editLkfKes = createAsyncThunk('dataLkf/editLkfKes', async ({ id, da
 
 export const getlkfDok = createAsyncThunk('dataLkf/lkfDok', async (_, thunkAPI) => {
   let url = `/api/dokumen`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().dataLkf.current_page}`,
       limit: `${thunkAPI.getState().dataLkf.per_page}`,
@@ -608,14 +514,9 @@ export const getlkfDok = createAsyncThunk('dataLkf/lkfDok', async (_, thunkAPI) 
 })
 
 export const createLkfDok = createAsyncThunk('dataLkf/createLkfDok', async ({ id, dataform }, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/lkfDokumen/${id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.put(url, dataform, config)

--- a/src/redux-store/lkf/index.js
+++ b/src/redux-store/lkf/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { STATUS_LKF } from '@/configs/lkfConfig'
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
@@ -38,12 +36,8 @@ const initialState = {
 
 export const getLkf = createAsyncThunk('jadwal/getLkf', async (_, thunkAPI) => {
   let url = `/api/lkf`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().lkf.current_page}`,
       limit: `${thunkAPI.getState().lkf.per_page}`,
@@ -77,13 +71,8 @@ export const getLkf = createAsyncThunk('jadwal/getLkf', async (_, thunkAPI) => {
 
 export const getShowLkf = createAsyncThunk('lkf/getShowLkf', async (id, thunkAPI) => {
   let url = `/api/lkf/${id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -108,13 +97,8 @@ export const getShowLkf = createAsyncThunk('lkf/getShowLkf', async (id, thunkAPI
 
 export const getInkfDetail = createAsyncThunk('lkf/getInkfDetail', async (id, thunkAPI) => {
   let url = `/api/lkfInkfDetail/${id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -139,13 +123,8 @@ export const getInkfDetail = createAsyncThunk('lkf/getInkfDetail', async (id, th
 
 export const lkfNilai = createAsyncThunk('lkf/lkfNilai', async (id, thunkAPI) => {
   let url = `/api/lkfNilai/${id}`
-  const session = await getSession()
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -171,13 +150,8 @@ export const lkfNilai = createAsyncThunk('lkf/lkfNilai', async (id, thunkAPI) =>
 export const simpanEva = createAsyncThunk('lkf/simpanEva', async ({ id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lkfSimpanEva/${id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -196,13 +170,8 @@ export const simpanEva = createAsyncThunk('lkf/simpanEva', async ({ id, dataform
 export const lkfSimpan = createAsyncThunk('lkf/lkfSimpan', async ({ lkf_id, dataform }, thunkAPI) => {
   try {
     let url = `/api/lkfSimpan/${lkf_id}`
-    const session = await getSession()
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -219,14 +188,9 @@ export const lkfSimpan = createAsyncThunk('lkf/lkfSimpan', async ({ lkf_id, data
 
 export const lkfSelesai = createAsyncThunk('lkf/lkfSelesai', async (lkf_id, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lkfSelesai/${lkf_id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, lkf_id, config)
 
     return resp.data
@@ -243,14 +207,9 @@ export const lkfSelesai = createAsyncThunk('lkf/lkfSelesai', async (lkf_id, thun
 
 export const lkfKembalikan = createAsyncThunk('lkf/lkfKembalikan', async (lkf_id, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lkfKembalikan/${lkf_id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, lkf_id, config)
 
     return resp.data
@@ -266,14 +225,9 @@ export const lkfKembalikan = createAsyncThunk('lkf/lkfKembalikan', async (lkf_id
 })
 
 export const lkfFormTabel = createAsyncThunk('lkf/lkfFormTabel', async (dataform, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/lkfFormTabel`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -292,14 +246,9 @@ export const lkfFormTabel = createAsyncThunk('lkf/lkfFormTabel', async (dataform
 
 export const lkfFormTabeledit = createAsyncThunk('lkf/lkfFormTabeledit', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lkfFormTabel/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataform, config)
 
@@ -317,12 +266,8 @@ export const lkfFormTabeledit = createAsyncThunk('lkf/lkfFormTabeledit', async (
 
 export const lkfFormTabeldelete = createAsyncThunk('lkf/lkfFormTabeldelete', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
     const resp = await customFetch.delete(`/api/lkfFormTabel/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      },
       params: {
         lkf_id: params.lkf_id
       }
@@ -346,14 +291,9 @@ export const lkfFormTabeldelete = createAsyncThunk('lkf/lkfFormTabeldelete', asy
 
 export const lkfKirim = createAsyncThunk('lkf/lkfKirim', async (lkf_id, thunkAPI) => {
   try {
-    const session = await getSession()
     let url = `/api/lkfKirim/${lkf_id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, lkf_id, config)
 
     return resp.data

--- a/src/redux-store/pdf/index.js
+++ b/src/redux-store/pdf/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -31,14 +29,9 @@ const initialState = {
 }
 
 export const getcetakSpi = createAsyncThunk('cetakPdf/getcetakSpi', async (surat_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/spi/${surat_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -62,14 +55,9 @@ export const getcetakSpi = createAsyncThunk('cetakPdf/getcetakSpi', async (surat
 })
 
 export const getcetakSbi = createAsyncThunk('cetakPdf/getcetakSbi', async (surat_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/sbi/${surat_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -93,14 +81,9 @@ export const getcetakSbi = createAsyncThunk('cetakPdf/getcetakSbi', async (surat
 })
 
 export const getcetakKonfirmasiFas = createAsyncThunk('cetakPdf/getcetakKonfirmasiFas', async (surat_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/konfirmasiFas/${surat_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -126,14 +109,9 @@ export const getcetakKonfirmasiFas = createAsyncThunk('cetakPdf/getcetakKonfirma
 export const getcetakKonfirmasiInsp = createAsyncThunk(
   'cetakPdf/getcetakKonfirmasiInsp',
   async (jadwal_id, thunkAPI) => {
-    const session = await getSession()
     let url = `/api/pdf/konfirmasiInsp/${jadwal_id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     try {
       const resp = await customFetch.get(url, config)
@@ -158,14 +136,9 @@ export const getcetakKonfirmasiInsp = createAsyncThunk(
 )
 
 export const getcetakFihi = createAsyncThunk('cetakPdf/getcetakFihi', async (fihi_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/fihi/${fihi_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -189,14 +162,9 @@ export const getcetakFihi = createAsyncThunk('cetakPdf/getcetakFihi', async (fih
 })
 
 export const getcetakFihiResume = createAsyncThunk('cetakPdf/getcetakFihiResume', async (fihi_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/resumeFihi/${fihi_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -220,14 +188,9 @@ export const getcetakFihiResume = createAsyncThunk('cetakPdf/getcetakFihiResume'
 })
 
 export const getcetakLkf = createAsyncThunk('cetakPdf/getcetakLkf', async (lkf_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/lkf/${lkf_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -251,14 +214,9 @@ export const getcetakLkf = createAsyncThunk('cetakPdf/getcetakLkf', async (lkf_i
 })
 
 export const getcetakJadwal = createAsyncThunk('cetakPdf/getcetakJadwal', async (jadwal_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/jadwal/${jadwal_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -282,14 +240,9 @@ export const getcetakJadwal = createAsyncThunk('cetakPdf/getcetakJadwal', async 
 })
 
 export const getcetakLhi = createAsyncThunk('cetakPdf/getcetakLhi', async (lhi_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/lhi/${lhi_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -313,14 +266,9 @@ export const getcetakLhi = createAsyncThunk('cetakPdf/getcetakLhi', async (lhi_i
 })
 
 export const getDraftSphi = createAsyncThunk('cetakPdf/getDraftSphi', async (lhi_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/pdf/draftSphi/${lhi_id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -344,14 +292,10 @@ export const getDraftSphi = createAsyncThunk('cetakPdf/getDraftSphi', async (lhi
 })
 
 export const downloadDokfile = createAsyncThunk('cetakPdf/downloadDokfile', async (id, thunkAPI) => {
-  const session = await getSession()
 
   const url = `/api/downloadDokFile/${id}`
 
   const config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     responseType: 'blob' // Set response type to blob to handle binary data
   }
 
@@ -378,14 +322,10 @@ export const downloadDokfile = createAsyncThunk('cetakPdf/downloadDokfile', asyn
 })
 
 export const downloadKtun = createAsyncThunk('cetakPdf/downloadKtun', async (id, thunkAPI) => {
-  const session = await getSession()
 
   const url = `/api/downloadKtun/${id}`
 
   const config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     responseType: 'blob' // Set response type to blob to handle binary data
   }
 

--- a/src/redux-store/referensi-balis/index.js
+++ b/src/redux-store/referensi-balis/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -28,12 +26,8 @@ const initialState = {
 
 export const getKabupaten = createAsyncThunk('refbalis/getKab', async (propinsi_id, thunkAPI) => {
   let url = `apiBalis/getKabupaten`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       propinsi_id: propinsi_id
     }
@@ -61,14 +55,9 @@ export const getKabupaten = createAsyncThunk('refbalis/getKab', async (propinsi_
 })
 
 export const getPropinsi = createAsyncThunk('refbalis/getPropinsi', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `apiBalis/getPropinsi`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -92,14 +81,9 @@ export const getPropinsi = createAsyncThunk('refbalis/getPropinsi', async (_, th
 })
 
 export const getBidang = createAsyncThunk('refbalis/getBidang', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `apiBalis/getBidang`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -123,14 +107,9 @@ export const getBidang = createAsyncThunk('refbalis/getBidang', async (_, thunkA
 })
 
 export const getModelSumber = createAsyncThunk('refbalis/getModelSumber', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `apiBalis/getModelSumber`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -154,14 +133,9 @@ export const getModelSumber = createAsyncThunk('refbalis/getModelSumber', async 
 })
 
 export const getSatuan = createAsyncThunk('refbalis/getSatuan', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `apiBalis/getSatuan`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -185,14 +159,9 @@ export const getSatuan = createAsyncThunk('refbalis/getSatuan', async (_, thunkA
 })
 
 export const getJenisPekerja = createAsyncThunk('refbalis/getJenisPekerja', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `apiBalis/getJenisPekerja`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -216,14 +185,9 @@ export const getJenisPekerja = createAsyncThunk('refbalis/getJenisPekerja', asyn
 })
 
 export const getListUser = createAsyncThunk('refbalis/getListUser', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `apiBalis/getListUser`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -247,14 +211,9 @@ export const getListUser = createAsyncThunk('refbalis/getListUser', async (_, th
 })
 
 export const getPenandatangan = createAsyncThunk('refbalis/getPenandatangan', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `api/ttd`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -278,13 +237,9 @@ export const getPenandatangan = createAsyncThunk('refbalis/getPenandatangan', as
 })
 
 export const getAlamat = createAsyncThunk('refbalis/getAlamat', async (fas_id, thunkAPI) => {
-  const session = await getSession()
   let url = `apiBalis/getFasilitasAlamat`
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       fas_id: fas_id
     }
@@ -312,13 +267,9 @@ export const getAlamat = createAsyncThunk('refbalis/getAlamat', async (fas_id, t
 })
 
 export const getDokumen = createAsyncThunk('refbalis/getDokumen', async (fas_id, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/dokumen`
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       fas_id: fas_id
     }

--- a/src/redux-store/referensi-infara/index.js
+++ b/src/redux-store/referensi-infara/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -29,14 +27,9 @@ const initialState = {
 }
 
 export const getInspektur = createAsyncThunk('refInfara/getInspektur', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `api/inspektur`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -60,13 +53,9 @@ export const getInspektur = createAsyncThunk('refInfara/getInspektur', async (_,
 })
 
 export const getInspekturRiwayat = createAsyncThunk('refInfara/getInspekturRiwayat', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `api/inspekturRiwayat`
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       status: 1
     }
@@ -94,13 +83,9 @@ export const getInspekturRiwayat = createAsyncThunk('refInfara/getInspekturRiway
 })
 
 export const getProsesLog = createAsyncThunk('refinfara/getProsesLog', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `api/proses/log`
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().refInfara.current_page}`,
       limit: `${thunkAPI.getState().refInfara.per_page}`,
@@ -137,14 +122,9 @@ export const getProsesLog = createAsyncThunk('refinfara/getProsesLog', async (_,
 })
 
 export const getInspekturDetail = createAsyncThunk('refInfara/getInspekturDetail', async (id, thunkAPI) => {
-  const session = await getSession()
   let url = `api/inspektur/${id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)

--- a/src/redux-store/sbi/index.js
+++ b/src/redux-store/sbi/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { JADWAL_PELAKSANAAN, JADWAL_SELESAI } from '@/configs/jadwalConfig'
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
@@ -30,13 +28,9 @@ const initialState = {
 }
 
 export const getListSbi = createAsyncThunk('sbi/getListSbi', async (_, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/sbi`
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       page: `${thunkAPI.getState().sbi.current_page}`,
       limit: `${thunkAPI.getState().sbi.per_page}`,
@@ -67,14 +61,9 @@ export const getListSbi = createAsyncThunk('sbi/getListSbi', async (_, thunkAPI)
 })
 
 export const getSbi = createAsyncThunk('sbi/getSbi', async (id, thunkAPI) => {
-  const session = await getSession()
   let url = `api/sbi/${id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -98,14 +87,9 @@ export const getSbi = createAsyncThunk('sbi/getSbi', async (id, thunkAPI) => {
 })
 
 export const getSpi = createAsyncThunk('sbi/getSpi', async (id, thunkAPI) => {
-  const session = await getSession()
   let url = `api/spi/${id}`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -129,14 +113,9 @@ export const getSpi = createAsyncThunk('sbi/getSpi', async (id, thunkAPI) => {
 })
 
 export const createSbi = createAsyncThunk('sbi/createSbi', async (dataform, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/sbi`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -155,13 +134,8 @@ export const createSbi = createAsyncThunk('sbi/createSbi', async (dataform, thun
 
 export const editSbi = createAsyncThunk('sbi/editSbi', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.put(`/api/sbi/${id}`, dataform, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.put(`/api/sbi/${id}`, dataform)
 
     thunkAPI.dispatch(clearValues())
 
@@ -178,14 +152,9 @@ export const editSbi = createAsyncThunk('sbi/editSbi', async ({ id, dataform }, 
 })
 
 export const createSpi = createAsyncThunk('sbi/createSpi', async (dataform, thunkAPI) => {
-  const session = await getSession()
   let url = `/api/spi`
 
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -204,13 +173,8 @@ export const createSpi = createAsyncThunk('sbi/createSpi', async (dataform, thun
 
 export const editSpi = createAsyncThunk('sbi/editSpi', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
 
-    const resp = await customFetch.put(`/api/spi/${id}`, dataform, {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    })
+    const resp = await customFetch.put(`/api/spi/${id}`, dataform)
 
     thunkAPI.dispatch(clearValues())
 

--- a/src/redux-store/validasi-data/index.js
+++ b/src/redux-store/validasi-data/index.js
@@ -1,8 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
 
-import { getSession } from 'next-auth/react'
-
 import { handleLogout } from '@/redux-store/auth'
 import customFetch from '@/utils/axios'
 
@@ -56,12 +54,8 @@ const initialState = {
 
 export const getRegistrasiSrp = createAsyncThunk('validasiData/getRegistrasiSrp', async (_, thunkAPI) => {
   let url = `/apiRegistrasi/srp`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session?.user?.accessToken
-    },
     params: {
       page: thunkAPI.getState().validasiData.current_page,
       limit: thunkAPI.getState().validasiData.per_page,
@@ -100,13 +94,7 @@ export const getRegistrasiSrp = createAsyncThunk('validasiData/getRegistrasiSrp'
 export const getRegsrpDetail = createAsyncThunk('validasiData/getRegsrpDetail', async (id, thunkAPI) => {
   let url = `/apiRegistrasi/srp/${id}`
 
-  const session = await getSession()
-
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -132,13 +120,7 @@ export const getRegsrpDetail = createAsyncThunk('validasiData/getRegsrpDetail', 
 export const createRegSumber = createAsyncThunk('validasiData/createRegSumber', async (dataform, thunkAPI) => {
   let url = `/apiRegistrasi/srp`
 
-  const session = await getSession()
-
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -168,13 +150,7 @@ export const editRegSumber = createAsyncThunk('validasiData/editRegSumber', asyn
   try {
     let url = `/apiRegistrasi/srp/${id}`
 
-    const session = await getSession()
-
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataforms, config)
 
@@ -201,12 +177,8 @@ export const editRegSumber = createAsyncThunk('validasiData/editRegSumber', asyn
 
 export const deleteRegSumber = createAsyncThunk('validasiData/deleteRegSumber', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
     const resp = await customFetch.delete(`/apiRegistrasi/srp/destroy`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      },
       params: {
         reg_srp_id: [params.id]
       }
@@ -236,13 +208,7 @@ export const deleteRegSumber = createAsyncThunk('validasiData/deleteRegSumber', 
 export const insertDocSumber = createAsyncThunk('validasiData/insertDocSumber', async (dataform, thunkAPI) => {
   let url = `/apiRegistrasi/srp/doc`
 
-  const session = await getSession()
-
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.post(url, dataform, config)
@@ -273,13 +239,7 @@ export const kevalidatorRegSumber = createAsyncThunk(
   async (dataform, thunkAPI) => {
     let url = `/apiRegistrasi/srp/kirim`
 
-    const session = await getSession()
-
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     try {
       const resp = await customFetch.post(url, dataform, config)
@@ -310,15 +270,10 @@ export const kirimOtorisatorSrp = createAsyncThunk(
   'validasiData/kirimOtorisatorSrp',
   async ({ id, dataform }, thunkAPI) => {
     try {
-      const session = await getSession()
 
       let url = `/apiRegistrasi/srp/kirimOtorisator/${id}`
 
-      let config = {
-        headers: {
-          'balis-token': session.user.accessToken
-        }
-      }
+      let config = {}
       const resp = await customFetch.put(url, dataform, config)
 
       return resp.data
@@ -336,15 +291,10 @@ export const kirimOtorisatorSrp = createAsyncThunk(
 
 export const kembalikanSrp = createAsyncThunk('validasiData/kembalikanSrp', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
 
     let url = `/apiRegistrasi/srp/kembalikan/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -361,15 +311,10 @@ export const kembalikanSrp = createAsyncThunk('validasiData/kembalikanSrp', asyn
 
 export const tolakSrp = createAsyncThunk('validasiData/tolakSrp', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
 
     let url = `/apiRegistrasi/srp/ditolak/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     return resp.data
@@ -386,15 +331,10 @@ export const tolakSrp = createAsyncThunk('validasiData/tolakSrp', async ({ id, d
 
 export const selesaiSrp = createAsyncThunk('validasiData/selesaiSrp', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
 
     let url = `/apiRegistrasi/srp/selesai/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     if (resp.data.status === 200) {
@@ -419,12 +359,8 @@ export const selesaiSrp = createAsyncThunk('validasiData/selesaiSrp', async ({ i
 
 export const dokumenRegSumber = createAsyncThunk('validasiData/dokumenRegSumber', async (reg_srp_id, thunkAPI) => {
   let url = `/apiRegistrasi/srp/doc`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    },
     params: {
       reg_srp_id: reg_srp_id,
       jenis_dokumen_id: thunkAPI.getState().validasiData.jenis_dokumen_id
@@ -456,14 +392,9 @@ export const validasiSrpSimpan = createAsyncThunk(
   'validasiData/validasiSrpSimpan',
   async ({ id, dataform }, thunkAPI) => {
     try {
-      const session = await getSession()
       let url = `/apiRegistrasi/srp/simpan/${id}`
 
-      let config = {
-        headers: {
-          'balis-token': session.user.accessToken
-        }
-      }
+      let config = {}
       const resp = await customFetch.put(url, dataform, config)
 
       return resp.data
@@ -482,12 +413,7 @@ export const validasiSrpSimpan = createAsyncThunk(
 export const getListMasterSrp = createAsyncThunk('validasiData/getListMasterSrp', async (_, thunkAPI) => {
   let url = `/apiRegistrasi/srp/list`
 
-  const session = await getSession()
-
   let config = {
-    headers: {
-      'balis-token': session?.user?.accessToken
-    },
     params: {
       limit: thunkAPI.getState().validasiData.limit,
       jenis_sumber_id: thunkAPI.getState().validasiData.jenis_sumber_id,
@@ -526,17 +452,12 @@ export const getListMasterSrp = createAsyncThunk('validasiData/getListMasterSrp'
 
 export const dispoManualSrp = createAsyncThunk('validasiData/dispoManualSrp', async ({ id, dataforms }, thunkAPI) => {
   try {
-    const session = await getSession()
 
     console.log(dataforms)
 
     let url = `/apiRegistrasi/srp/dispoManual/${id}`
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataforms, config)
 
     return resp.data
@@ -553,12 +474,8 @@ export const dispoManualSrp = createAsyncThunk('validasiData/dispoManualSrp', as
 
 export const getSensusSrp = createAsyncThunk('validasiData/getSensusSrp', async (_, thunkAPI) => {
   let url = `/api/validasi/sumber`
-  const session = await getSession()
 
   let config = {
-    headers: {
-      'balis-token': session?.user?.accessToken
-    },
     params: {
       page: thunkAPI.getState().validasiData.current_page,
       limit: thunkAPI.getState().validasiData.per_page,
@@ -602,13 +519,7 @@ export const getSensusSrp = createAsyncThunk('validasiData/getSensusSrp', async 
 export const getSensusSrpDetail = createAsyncThunk('validasiData/getSensusSrpDetail', async (id, thunkAPI) => {
   let url = `/api/validasi/sumber/${id}`
 
-  const session = await getSession()
-
-  let config = {
-    headers: {
-      'balis-token': session.user.accessToken
-    }
-  }
+  let config = {}
 
   try {
     const resp = await customFetch.get(url, config)
@@ -635,13 +546,7 @@ export const updateSumber = createAsyncThunk('validasiData/updateSumber', async 
   try {
     let url = `/api/validasi/sumber/${id}`
 
-    const session = await getSession()
-
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.put(url, dataforms, config)
 
@@ -668,17 +573,12 @@ export const updateSumber = createAsyncThunk('validasiData/updateSumber', async 
 
 export const ubahStatusSrp = createAsyncThunk('validasiData/ubahStatusSrp', async ({ id, dataform }, thunkAPI) => {
   try {
-    const session = await getSession()
 
     let url = `/api/validasi/sumber/ubahStatusFas/${id}`
 
     console.log(dataform)
 
-    let config = {
-      headers: {
-        'balis-token': session.user.accessToken
-      }
-    }
+    let config = {}
     const resp = await customFetch.put(url, dataform, config)
 
     if (resp.data.status === 200) {
@@ -705,14 +605,9 @@ export const validasiSensusSimpan = createAsyncThunk(
   'validasiData/validasiSensusSimpan',
   async ({ id, dataform }, thunkAPI) => {
     try {
-      const session = await getSession()
       let url = `/api/validasi/sumber/simpan/${id}`
 
-      let config = {
-        headers: {
-          'balis-token': session.user.accessToken
-        }
-      }
+      let config = {}
       const resp = await customFetch.put(url, dataform, config)
 
       return resp.data
@@ -730,15 +625,10 @@ export const validasiSensusSimpan = createAsyncThunk(
 
 export const simpanInstansi = createAsyncThunk('validasiData/simpanInstansi', async (dataform, thunkAPI) => {
   try {
-    const session = await getSession()
 
     const url = `/api/validasi/sumber/fasSumber`
 
-    const config = {
-      headers: {
-        'balis-token': session?.user?.accessToken
-      }
-    }
+    let config = {}
 
     const resp = await customFetch.post(url, dataform, config)
 
@@ -756,13 +646,10 @@ export const simpanInstansi = createAsyncThunk('validasiData/simpanInstansi', as
 
 export const uploadSrpDok = createAsyncThunk('validasiData/uploadSrpDok', async (dataform, thunkAPI) => {
   console.log('upload')
-
-  const session = await getSession()
   let url = `/api/validasi/sumber/doc`
 
   let config = {
     headers: {
-      'balis-token': session.user.accessToken,
       'Content-Type': 'multipart/form-data'
     }
   }
@@ -784,12 +671,8 @@ export const uploadSrpDok = createAsyncThunk('validasiData/uploadSrpDok', async 
 
 export const deleteSrpDok = createAsyncThunk('validasiData/deleteSrpDok', async (params, thunkAPI) => {
   try {
-    const session = await getSession()
 
     const resp = await customFetch.delete(`/api/validasi/sumber/deleteDoc/${params.id}`, {
-      headers: {
-        'balis-token': session.user.accessToken
-      },
       params: {
         reg_srp_id: [params.id]
       }


### PR DESCRIPTION
## Summary
- remove manual balis-token headers and session lookups from redux async thunks so requests rely on the axios interceptor
- keep required request params/configuration and preserve multipart form-data headers where needed
- retain getSession only where user id is required by business logic

## Testing
- pnpm lint *(fails: No package manifest found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8cfff4e208329b2922da18d51dda5