### PR TITLE
Switch legacy balis-token headers to Bearer Authorization

### DIFF
--- a/src/app/(dashboard)/(private)/data-inspeksi/kamera/server.js
+++ b/src/app/(dashboard)/(private)/data-inspeksi/kamera/server.js
@@ -14,7 +14,7 @@ export async function fetchDatakamera(page = 1, per_page = 20) {
 
   const config = {
     headers: {
-      'balis-token': session.user?.accessToken || ''
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     params: {
       page: page,

--- a/src/app/(dashboard)/(private)/data-inspeksi/server-action/server.js
+++ b/src/app/(dashboard)/(private)/data-inspeksi/server-action/server.js
@@ -14,7 +14,7 @@ export async function fetchDataKtun(params = {}) {
 
   const config = {
     headers: {
-      'balis-token': session.user?.accessToken || ''
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     params: {
       page: params.page || 1,

--- a/src/app/(dashboard)/(private)/data-inspeksi/srp/server.js
+++ b/src/app/(dashboard)/(private)/data-inspeksi/srp/server.js
@@ -16,7 +16,7 @@ export async function fetchDataSrp(params = {}) {
 
   const config = {
     headers: {
-      'balis-token': session.user?.accessToken || ''
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     params: {
       page: params.page || 1,

--- a/src/app/(dashboard)/(private)/data-umum/server-action/fetchJadwal.js
+++ b/src/app/(dashboard)/(private)/data-umum/server-action/fetchJadwal.js
@@ -21,7 +21,7 @@ export async function fetchJadwal(searchParams = {}) {
 
   const config = {
     headers: {
-      'balis-token': session.user?.accessToken
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     params: {
       page,

--- a/src/app/(dashboard)/(private)/instansi-terjadwal/server-action/server.js
+++ b/src/app/(dashboard)/(private)/instansi-terjadwal/server-action/server.js
@@ -18,7 +18,7 @@ export async function fetchInstansiTerjadwal(tahun = '') {
 
   const config = {
     headers: {
-      'balis-token': session.user?.accessToken || ''
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     params: {
       limit: 1000,
@@ -53,7 +53,7 @@ export async function fetchKelompok() {
 
   const config = {
     headers: {
-      'balis-token': session.user?.accessToken || ''
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     withCredentials: true
   }

--- a/src/app/(dashboard)/(private)/konfirmasi-inspektur/server-action/server.js
+++ b/src/app/(dashboard)/(private)/konfirmasi-inspektur/server-action/server.js
@@ -14,7 +14,7 @@ export async function fetchKonfirmasiInspektur(page = 1, per_page = 20) {
 
   const config = {
     headers: {
-      'balis-token': session.user?.accessToken || ''
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     params: {
       page: page,

--- a/src/app/api/lvkf-tahunan/[id]/routes.js
+++ b/src/app/api/lvkf-tahunan/[id]/routes.js
@@ -17,7 +17,7 @@ export async function GET(_req, { params }) {
     const { id } = params
 
     const resp = await customFetch.get(`/api/lkf/${id}`, {
-      headers: { 'balis-token': session.user?.accessToken || '' }
+      headers: { Authorization: `Bearer ${session?.user?.accessToken ?? ''}` }
     })
 
     if (resp?.status === 200 && resp?.data?.status === 200) {

--- a/src/app/api/lvkf-tahunan/route.js
+++ b/src/app/api/lvkf-tahunan/route.js
@@ -41,7 +41,7 @@ export async function GET(req) {
     // Proxy ke backend lama
     const resp = await customFetch.get('/api/lkf', {
       headers: {
-        'balis-token': session.user?.accessToken || ''
+        Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
       },
       params: qp
     })

--- a/src/app/api/lvkf/[id]/route.js
+++ b/src/app/api/lvkf/[id]/route.js
@@ -17,7 +17,7 @@ export async function GET(_req, { params }) {
     const { id } = params
 
     const resp = await customFetch.get(`/api/lkf/${id}`, {
-      headers: { 'balis-token': session.user?.accessToken || '' }
+      headers: { Authorization: `Bearer ${session?.user?.accessToken ?? ''}` }
     })
 
     if (resp?.status === 200 && resp?.data?.status === 200) {

--- a/src/app/api/lvkf/route.js
+++ b/src/app/api/lvkf/route.js
@@ -41,7 +41,7 @@ export async function GET(req) {
     // Proxy to legacy backend
     const resp = await customFetch.get('/api/lkf', {
       headers: {
-        'balis-token': session.user?.accessToken || ''
+        Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
       },
       params: qp
     })

--- a/src/app/server/tarik.js
+++ b/src/app/server/tarik.js
@@ -17,7 +17,7 @@ export async function fetchKegiatan() {
 
   const config = {
     headers: {
-      'balis-token': session?.user?.accessToken
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     withCredentials: true
   }
@@ -44,7 +44,7 @@ export async function fetchSyaratKegiatan(kelompok_id) {
 
   const config = {
     headers: {
-      'balis-token': session.user?.accessToken || ''
+      Authorization: `Bearer ${session?.user?.accessToken ?? ''}`
     },
     withCredentials: true
   }

--- a/src/components/widget/FasilitasAutocomplete.js
+++ b/src/components/widget/FasilitasAutocomplete.js
@@ -28,7 +28,11 @@ const FasilitasAutocomplete = ({ value, onChange }) => {
         const session = await getSession()
 
         const res = await customFetch.get('/api/data/fasilitas', {
-          headers: { 'balis-token': session?.user?.accessToken },
+          headers: {
+            Authorization: session?.user?.accessToken
+              ? `Bearer ${session.user.accessToken}`
+              : ''
+          },
           params: { page: 1, limit: 100, cari: query }
         })
 

--- a/src/components/widget/LingkupAutoComplete.js
+++ b/src/components/widget/LingkupAutoComplete.js
@@ -38,7 +38,7 @@ const LingkupAutoComplete = ({ value, onChange, flagKegiatan }) => {
         }
 
         const response = await customFetch.get('/apiBalis/kegiatan', {
-          headers: { 'balis-token': session.user.accessToken },
+          headers: { Authorization: `Bearer ${session.user.accessToken}` },
           params
         })
 

--- a/src/components/widget/UserInspeksiAutocomplete.js
+++ b/src/components/widget/UserInspeksiAutocomplete.js
@@ -28,7 +28,11 @@ const UserInspeksiAutocomplete = ({ value, onChange }) => {
         const session = await getSession()
 
         const res = await customFetch.get('/api/akunInspeksi', {
-          headers: { 'balis-token': session?.user?.accessToken },
+          headers: {
+            Authorization: session?.user?.accessToken
+              ? `Bearer ${session.user.accessToken}`
+              : ''
+          },
           params: {
             page: 1,
             limit: 100,


### PR DESCRIPTION
## Summary
- replace all remaining `balis-token` request headers with `Authorization: Bearer` in server actions and API routes
- update client autocomplete widgets to send Bearer tokens when fetching data

## Testing
- pnpm lint *(fails: No package.json manifest found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d5f6085c83298d09bd46ccc419b6