### PR TITLE
Add jadwal koordinator reducer to store

### DIFF
--- a/src/redux-store/index.js
+++ b/src/redux-store/index.js
@@ -18,6 +18,7 @@ import fihi from './fihi'
 import dataFihi from './fihi/dataFihi'
 import jadwal from './jadwal'
 import jadwalFas from './jadwal-fas'
+import jadwalKoor from './jadwal-koord'
 import lhi from './lhi'
 import dataLhi from './lhi/dataLhi'
 import lkf from './lkf'
@@ -42,6 +43,7 @@ export const store = configureStore({
     ikk,
     tabel,
     jadwal,
+    jadwalKoor,
     jadwalFas,
     akun,
     sbi,


### PR DESCRIPTION
## Summary
- import the `jadwalKoor` reducer into the Redux store configuration
- register `jadwalKoor` in the store's reducer map

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8e0c37bd08329a682f70705f123b3