### PR TITLE
Refactor Grid2 breakpoint props to size object

### DIFF
--- a/src/app/(dashboard)/(private)/admin-user/akun-balis/page.jsx
+++ b/src/app/(dashboard)/(private)/admin-user/akun-balis/page.jsx
@@ -119,7 +119,7 @@ function Index() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <Grid2 container spacing={2} columns={{ xs: 12, md: 12 }} alignItems='center' sx={{ mb: 2 }}>
           {/* cari */}
-          <Grid2 xs={12} md={3}>
+          <Grid2 size={{ xs: 12, md: 3 }}>
             <Controller
               name='cari'
               control={control}
@@ -139,7 +139,7 @@ function Index() {
           </Grid2>
 
           {/* fasilitas */}
-          <Grid2 xs={12} md={4}>
+          <Grid2 size={{ xs: 12, md: 4 }}>
             <Controller
               name='fas_id'
               control={control}
@@ -156,7 +156,7 @@ function Index() {
           </Grid2>
 
           {/* akses */}
-          <Grid2 xs={12} md={3}>
+          <Grid2 size={{ xs: 12, md: 3 }}>
             <CustomAutocomplete
               control={control}
               errors={errors.merk}
@@ -169,13 +169,13 @@ function Index() {
           </Grid2>
 
           {/* tombol */}
-          <Grid2 xs={12} md={1}>
+          <Grid2 size={{ xs: 12, md: 1 }}>
             <Button type='submit' fullWidth variant='contained' startIcon={<Icon icon='tabler:search' fontSize={18} />}>
               cari
             </Button>
           </Grid2>
 
-          <Grid2 xs={12} md={1}>
+          <Grid2 size={{ xs: 12, md: 1 }}>
             <Button variant='tonal' color='primary' type='reset' onClick={handleReset} fullWidth>
               Reset
             </Button>

--- a/src/views/validasi-srp/FormSumber.jsx
+++ b/src/views/validasi-srp/FormSumber.jsx
@@ -187,7 +187,7 @@ const FormSumber = ({ data }) => {
         <CardHeader title='Form Data Registrasi SRP' />
         <CardContent>
           <form id='myForm' onSubmit={handleSubmit(onSubmit)}>
-            <Grid2 item='true' xs={12}>
+            <Grid2 item size={{ xs: 12 }}>
               <Box display='flex' alignItems='stretch' gap={2}>
                 <Box flex={1}>
                   <Controller


### PR DESCRIPTION
## Summary
- update Grid2 usage in FormSumber to use the new size prop instead of deprecated breakpoint props
- adjust admin Akun Balis filters layout to the size object syntax for Grid2 items

## Testing
- pnpm lint *(fails: ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7786a02c8329a86920fa344c0833