### PR TITLE
refactor: update grid breakpoints to v6 size syntax

### DIFF
--- a/src/app/(dashboard)/(private)/admin-user/akun-balis/page.jsx
+++ b/src/app/(dashboard)/(private)/admin-user/akun-balis/page.jsx
@@ -119,7 +119,7 @@ function Index() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <Grid2 container spacing={2} columns={{ xs: 12, md: 12 }} alignItems='center' sx={{ mb: 2 }}>
           {/* cari */}
-          <Grid2 xs={12} md={3}>
+          <Grid2 size={{ xs: 12, md: 3 }}>
             <Controller
               name='cari'
               control={control}
@@ -139,7 +139,7 @@ function Index() {
           </Grid2>
 
           {/* fasilitas */}
-          <Grid2 xs={12} md={4}>
+          <Grid2 size={{ xs: 12, md: 4 }}>
             <Controller
               name='fas_id'
               control={control}
@@ -156,7 +156,7 @@ function Index() {
           </Grid2>
 
           {/* akses */}
-          <Grid2 xs={12} md={3}>
+          <Grid2 size={{ xs: 12, md: 3 }}>
             <CustomAutocomplete
               control={control}
               errors={errors.merk}
@@ -169,13 +169,13 @@ function Index() {
           </Grid2>
 
           {/* tombol */}
-          <Grid2 xs={12} md={1}>
+          <Grid2 size={{ xs: 12, md: 1 }}>
             <Button type='submit' fullWidth variant='contained' startIcon={<Icon icon='tabler:search' fontSize={18} />}>
               cari
             </Button>
           </Grid2>
 
-          <Grid2 xs={12} md={1}>
+          <Grid2 size={{ xs: 12, md: 1 }}>
             <Button variant='tonal' color='primary' type='reset' onClick={handleReset} fullWidth>
               Reset
             </Button>

--- a/src/app/(dashboard)/(private)/jadwal/[id]/page.jsx
+++ b/src/app/(dashboard)/(private)/jadwal/[id]/page.jsx
@@ -45,7 +45,7 @@ const Detail = () => {
         </Grid>
       </Grid>
       <Grid container sx={{ marginTop: 4 }}>
-        <Grid xs={12} size={{ xs: 12 }}>
+        <Grid size={{ xs: 12 }}>
           {detailJadwal && <Inspektur detail={detailJadwal} />}
         </Grid>
       </Grid>

--- a/src/app/(dashboard)/(private)/jadwal/form-jadwal/page.jsx
+++ b/src/app/(dashboard)/(private)/jadwal/form-jadwal/page.jsx
@@ -122,7 +122,7 @@ const FormJadwal = () => {
               </Grid>
               <Grid size={{ xs: 12, md: 12, sm: 12 }}>
                 <Grid container spacing={2}>
-                  <Grid sm={6} size={{ sm: 6 }}>
+                  <Grid size={{ sm: 6 }}>
                     <Controller
                       name='tgl_mulai'
                       control={control}

--- a/src/components/jadwal/SearchContainer.js
+++ b/src/components/jadwal/SearchContainer.js
@@ -102,7 +102,7 @@ const SearchContainer = () => {
             required={false}
           />
         </Grid>
-        <Grid xs={3} size={{ xs: 3 }}>
+        <Grid size={{ xs: 3 }}>
           <Controller
             name='search'
             control={control}

--- a/src/views/data-inspeksi/ktun/Index.js
+++ b/src/views/data-inspeksi/ktun/Index.js
@@ -112,7 +112,7 @@ export default function Index() {
             />
           </Grid>
 
-          <Grid xs={12} sm={3}>
+          <Grid size={{ xs: 12, sm: 3 }}>
             <Controller
               name='cari'
               control={control}
@@ -121,7 +121,7 @@ export default function Index() {
             />
           </Grid>
 
-          <Grid xs={12}>
+          <Grid size={{ xs: 12 }}>
             <Button type='submit' variant='contained'>
               Cari
             </Button>

--- a/src/views/data-inspeksi/srp/Index.js
+++ b/src/views/data-inspeksi/srp/Index.js
@@ -151,7 +151,7 @@ export default function Index() {
             />
           </Grid>
 
-          <Grid xs={12} sm={3}>
+          <Grid size={{ xs: 12, sm: 3 }}>
             <Controller
               name='cari'
               control={control}
@@ -162,7 +162,7 @@ export default function Index() {
             />
           </Grid>
 
-          <Grid xs={12}>
+          <Grid size={{ xs: 12 }}>
             <Button type='submit' variant='contained'>
               Cari
             </Button>

--- a/src/views/fihi/form/FormEvaluasiFihi.js
+++ b/src/views/fihi/form/FormEvaluasiFihi.js
@@ -138,7 +138,7 @@ const FormEvaluasiFihi = ({ inkf, temuanItem, detailIkk }) => {
                 <Tooltip key={index} title={uraian} placement='top'>
                   <Grid
                     item
-                    xs={12 / detailIkk.length}
+                    size={{ xs: 12 / detailIkk.length }}
                     sx={{ backgroundColor: '#d6cbe0', padding: 1, borderRadius: 1, textAlign: 'center' }}
                   >
                     <FormControlLabel value={ikk_item_id} control={<Radio />} label={`${kode} (${nilai_ikk})`} />

--- a/src/views/frontend/lvkf-tahunan/LkfCreateButton.js
+++ b/src/views/frontend/lvkf-tahunan/LkfCreateButton.js
@@ -137,7 +137,7 @@ export default function LkfCreateButton({
           </Box>
 
           <Grid container spacing={2}>
-            <Grid item xs={12}>
+            <Grid item size={{ xs: 12 }}>
               <FormControl fullWidth size='small'>
                 <InputLabel id='kelompok-label'>Pilih Kelompok</InputLabel>
                 <Select
@@ -158,7 +158,7 @@ export default function LkfCreateButton({
               </FormControl>
             </Grid>
 
-            <Grid item xs={12} md={6}>
+            <Grid item size={{ xs: 12, md: 6 }}>
               <FormControl fullWidth size='small'>
                 <InputLabel id='propinsi-label'>Propinsi</InputLabel>
                 <Select
@@ -179,7 +179,7 @@ export default function LkfCreateButton({
               </FormControl>
             </Grid>
 
-            <Grid item xs={12} md={6}>
+            <Grid item size={{ xs: 12, md: 6 }}>
               <FormControl fullWidth size='small'>
                 <InputLabel id='kab-label'>Kabupaten / Kota</InputLabel>
                 <Select
@@ -200,7 +200,7 @@ export default function LkfCreateButton({
               </FormControl>
             </Grid>
 
-            <Grid item xs={12}>
+            <Grid item size={{ xs: 12 }}>
               <FormControl fullWidth size='small'>
                 <InputLabel id='alamat-label'>Alamat</InputLabel>
                 <Select

--- a/src/views/lhi/form/FormEvaluasiLhi.js
+++ b/src/views/lhi/form/FormEvaluasiLhi.js
@@ -138,7 +138,7 @@ const FormEvaluasiLhi = ({ inkf, temuanItem, detailIkk }) => {
                 <Tooltip key={index} title={uraian} placement='top'>
                   <Grid
                     item
-                    xs={12 / detailIkk.length}
+                    size={{ xs: 12 / detailIkk.length }}
                     sx={{ backgroundColor: '#d6cbe0', padding: 1, borderRadius: 1, textAlign: 'center' }}
                   >
                     <FormControlLabel value={ikk_item_id} control={<Radio />} label={`${kode} (${nilai_ikk})`} />

--- a/src/views/lhi/form/FormLhiLokasi.js
+++ b/src/views/lhi/form/FormLhiLokasi.js
@@ -91,9 +91,9 @@ const FormLhiLokasi = ({ data, open, handleClose }) => {
         </TableHead>
       </Table>
       <form id='myForm' onSubmit={handleSubmit(onSubmit)}>
-        <Grid item xs={12} sm={12}>
+        <Grid item size={{ xs: 12, sm: 12 }}>
           <Grid container spacing={2} sx={{ marginTop: 2 }}>
-            <Grid item sm={6}>
+            <Grid item size={{ sm: 6 }}>
               <Controller
                 name='tgl_mulai'
                 control={control}
@@ -129,7 +129,7 @@ const FormLhiLokasi = ({ data, open, handleClose }) => {
                 }}
               />
             </Grid>
-            <Grid item='true' sm={6}>
+            <Grid item='true' size={{ sm: 6 }}>
               <Controller
                 name='tgl_akhir'
                 control={control}
@@ -167,7 +167,7 @@ const FormLhiLokasi = ({ data, open, handleClose }) => {
             </Grid>
           </Grid>
         </Grid>
-        <Grid item='true' xs={12} sm={6} sx={{ marginTop: 2 }}>
+        <Grid item='true' size={{ xs: 12, sm: 6 }} sx={{ marginTop: 2 }}>
           <Controller
             name='status_inspeksi'
             control={control}
@@ -215,7 +215,7 @@ const FormLhiLokasi = ({ data, open, handleClose }) => {
             }}
           />
         </Grid>
-        <Grid item='true' xs={12} sm={12} sx={{ marginTop: 4 }}>
+        <Grid item='true' size={{ xs: 12, sm: 12 }} sx={{ marginTop: 4 }}>
           <CustomAutocomplete
             control={control}
             errors={errors.alamat_id}

--- a/src/views/sensus-srp/FormSensus.jsx
+++ b/src/views/sensus-srp/FormSensus.jsx
@@ -145,7 +145,7 @@ const FormSensus = ({ detailSrp, id }) => {
           </Grid>
 
           {/* CATATAN VALIDASI */}
-          <Grid item='true' xs={12} sm={6}>
+          <Grid item='true' size={{ xs: 12, sm: 6 }}>
             <Controller
               name='catatan'
               control={control}
@@ -185,7 +185,7 @@ const FormSensus = ({ detailSrp, id }) => {
             flexDirection: 'column'
           }}
         >
-          <Grid item='true' xs={12} sm={6}>
+          <Grid item='true' size={{ xs: 12, sm: 6 }}>
             <FormControl error={Boolean(errors.konfirmasi)} fullWidth>
               <FormLabel sx={{ mb: 1 }}>
                 <b>Kelengkapan</b>
@@ -216,7 +216,7 @@ const FormSensus = ({ detailSrp, id }) => {
           </Grid>
 
           {/* CATATAN KELENGKAPAN */}
-          <Grid item='true' xs={12} sm={6}>
+          <Grid item='true' size={{ xs: 12, sm: 6 }}>
             <Controller
               name='catatan_lengkap'
               control={control}
@@ -240,7 +240,7 @@ const FormSensus = ({ detailSrp, id }) => {
           </Grid>
         </Grid>
 
-        <Grid item='true' xs={12}>
+        <Grid item='true' size={{ xs: 12 }}>
           <Button type='submit' variant='contained' sx={{ float: 'right' }}>
             Submit
           </Button>

--- a/src/views/sensus-srp/Search.jsx
+++ b/src/views/sensus-srp/Search.jsx
@@ -249,7 +249,7 @@ const Search = () => {
             )}
           />
         </Grid>
-        <Grid item='true' xs={6} container justifyContent='flex-end' spacing={2}>
+        <Grid item='true' size={{ xs: 6 }} container justifyContent='flex-end' spacing={2}>
           <Grid item='true'>
             <Button type='submit' variant='contained'>
               Cari

--- a/src/views/validasi-srp/DetailRegSrp.js
+++ b/src/views/validasi-srp/DetailRegSrp.js
@@ -17,7 +17,7 @@ const DetailRegSrp = ({ detailRegsrp }) => {
     <>
       {Number(detailRegsrp.jenis_sumber_id) === 2 && (
         <Grid container>
-          <Grid item='true' xl={12} md={6} xs={12} sm={12} paddingRight={2}>
+          <Grid item='true' size={{ xs: 12, sm: 12, md: 6, xl: 12 }} paddingRight={2}>
             <h5>Detail Unit Sumber Radiasi Pengion</h5>
             <Table size='small' sx={{ border: '1px solid #ccc', borderCollapse: 'collapse' }}>
               <TableHead>

--- a/src/views/validasi-srp/FormDisposisi.jsx
+++ b/src/views/validasi-srp/FormDisposisi.jsx
@@ -81,7 +81,7 @@ const FormDisposisi = ({ datasrp, regsrpId, open, handleClose }) => {
             </div>
             <form id='myForm' onSubmit={handleSubmit(onSubmit)}>
               <Grid container spacing={1} alignItems='center'>
-                <Grid item='true' xs={12} sm={8}>
+                <Grid item='true' size={{ xs: 12, sm: 8 }}>
                   <Controller
                     name='validator_id'
                     control={control}
@@ -99,7 +99,7 @@ const FormDisposisi = ({ datasrp, regsrpId, open, handleClose }) => {
                   />
                 </Grid>
 
-                <Grid item='true' xs={12} sm={2}>
+                <Grid item='true' size={{ xs: 12, sm: 2 }}>
                   <Button type='submit' variant='outlined' sx={{ mt: 5 }}>
                     disposisi
                   </Button>

--- a/src/views/validasi-srp/FormSumber.jsx
+++ b/src/views/validasi-srp/FormSumber.jsx
@@ -187,7 +187,7 @@ const FormSumber = ({ data }) => {
         <CardHeader title='Form Data Registrasi SRP' />
         <CardContent>
           <form id='myForm' onSubmit={handleSubmit(onSubmit)}>
-            <Grid2 item='true' xs={12}>
+            <Grid2 item='true' size={{ xs: 12 }}>
               <Box display='flex' alignItems='stretch' gap={2}>
                 <Box flex={1}>
                   <Controller

--- a/src/views/validasi-srp/FormValidasiSrp.jsx
+++ b/src/views/validasi-srp/FormValidasiSrp.jsx
@@ -138,7 +138,7 @@ const FormValidasiSrp = ({ detailRegsrp, id, mastersumber }) => {
           </Grid>
 
           {/* CATATAN VALIDASI */}
-          <Grid item='true' xs={12} sm={6}>
+          <Grid item='true' size={{ xs: 12, sm: 6 }}>
             <Controller
               name='catatan'
               control={control}
@@ -178,7 +178,7 @@ const FormValidasiSrp = ({ detailRegsrp, id, mastersumber }) => {
             flexDirection: 'column'
           }}
         >
-          <Grid item='true' xs={12} sm={6}>
+          <Grid item='true' size={{ xs: 12, sm: 6 }}>
             <FormControl error={Boolean(errors.konfirmasi)} fullWidth>
               <FormLabel sx={{ mb: 1 }}>
                 <b>Kelengkapan</b>
@@ -209,7 +209,7 @@ const FormValidasiSrp = ({ detailRegsrp, id, mastersumber }) => {
           </Grid>
 
           {/* CATATAN KELENGKAPAN */}
-          <Grid item='true' xs={12} sm={6}>
+          <Grid item='true' size={{ xs: 12, sm: 6 }}>
             <Controller
               name='catatan_lengkap'
               control={control}
@@ -234,7 +234,7 @@ const FormValidasiSrp = ({ detailRegsrp, id, mastersumber }) => {
         </Grid>
 
         {[1, 2].includes(detailRegsrp.tahap_reg_id) && (
-          <Grid item='true' xs={12}>
+          <Grid item='true' size={{ xs: 12 }}>
             <Button type='submit' variant='contained' sx={{ float: 'right' }}>
               Submit
             </Button>

--- a/src/views/validasi-srp/SearchValidasi.js
+++ b/src/views/validasi-srp/SearchValidasi.js
@@ -119,7 +119,7 @@ const SearchValidasi = ({ showExcelSelect }) => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Grid container spacing={2} alignItems='center'>
-        <Grid item='true' xs={4}>
+        <Grid item='true' size={{ xs: 4 }}>
           <Controller
             name='cari'
             control={control}
@@ -139,7 +139,7 @@ const SearchValidasi = ({ showExcelSelect }) => {
             )}
           />
         </Grid>
-        <Grid item='true' xs={2}>
+        <Grid item='true' size={{ xs: 2 }}>
           <Controller
             name='per_page'
             control={control}
@@ -155,7 +155,7 @@ const SearchValidasi = ({ showExcelSelect }) => {
           />
         </Grid>
 
-        <Grid item='true' xs={6} container justifyContent='flex-end' spacing={2}>
+        <Grid item='true' size={{ xs: 6 }} container justifyContent='flex-end' spacing={2}>
           <Grid item='true'>
             <Button type='submit' variant='contained'>
               Cari


### PR DESCRIPTION
## Summary
- replace deprecated breakpoint props on MUI Grid components with the v6 `size` API across dashboard scheduling, validation, and reference views
- ensure all Grid containers rely on the new syntax, including complex layouts in validation, LVKF, and inspection forms

## Testing
- pnpm lint *(fails: No package.json found in /workspace/inf-newapi)*

------
https://chatgpt.com/codex/tasks/task_e_68ca77815ed48329abc0010b525ec247