### PR TITLE
Fix ModalKembali selector memoization

### DIFF
--- a/src/views/jadwal/action/ModalKembali.js
+++ b/src/views/jadwal/action/ModalKembali.js
@@ -22,19 +22,10 @@ const ModalKembali = ({ data, openBack, handleClose, view = 'verifikator' }) => 
 
   const useKoordinator = view === 'koordinator'
 
-  const { detailJadwal, tab } = useSelector(store => {
-    if (useKoordinator) {
-      return {
-        detailJadwal: store.jadwalKoord.detailJadwal,
-        tab: store.jadwalKoord.tab
-      }
-    }
-
-    return {
-      detailJadwal: store.jadwal.detailJadwal,
-      tab: store.jadwal.tab
-    }
-  })
+  const detailJadwal = useSelector(store =>
+    useKoordinator ? store.jadwalKoord.detailJadwal : store.jadwal.detailJadwal
+  )
+  const tab = useSelector(store => (useKoordinator ? store.jadwalKoord.tab : store.jadwal.tab))
 
   useEffect(() => {
     if (jadwal_id !== undefined && jadwal_id !== null) {


### PR DESCRIPTION
## Summary
- use separate selectors in ModalKembali to avoid returning new object references on each render
- ensure coordinator and verifikator views read schedule detail and tab state without triggering extra renders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbb2d1c020832982a3da96661ee2ad